### PR TITLE
feat(spec-kit): SPEC-KIT-974 close-out - risk auto-export, import/GC enhancements

### DIFF
--- a/codex-rs/SPEC.md
+++ b/codex-rs/SPEC.md
@@ -95,9 +95,9 @@ These invariants MUST NOT be violated:
 
 ### In Progress
 
-| Spec         | Status      | Owner        | Next Action                                                  |
-| ------------ | ----------- | ------------ | ------------------------------------------------------------ |
-| SPEC-KIT-974 | In Progress | Platform Eng | AC verified (7/8); AC#4 risk-export unimplemented - escalate |
+| Spec         | Status      | Owner        | Next Action                                 |
+| ------------ | ----------- | ------------ | ------------------------------------------- |
+| SPEC-KIT-974 | In Progress | Platform Eng | 8/8 verified; ready for completion/closeout |
 
 ### Completed (Recent)
 

--- a/codex-rs/cli/src/speckit_cmd.rs
+++ b/codex-rs/cli/src/speckit_cmd.rs
@@ -4332,14 +4332,14 @@ fn run_capsule_import(capsule_path: &PathBuf, args: CapsuleImportArgs) -> anyhow
 ///
 /// SPEC-KIT-974: Garbage collect expired export files.
 fn run_capsule_gc(capsule_path: &PathBuf, args: CapsuleGcArgs) -> anyhow::Result<()> {
-    // Open workspace capsule read-only (GC operates on export files, not capsule itself)
+    // SPEC-KIT-974 AC#8: Open write-capable so audit events are persisted
     let config = CapsuleConfig {
         capsule_path: capsule_path.clone(),
         workspace_id: "cli".to_string(),
         ..Default::default()
     };
 
-    let handle = match CapsuleHandle::open_read_only(config) {
+    let handle = match CapsuleHandle::open(config) {
         Ok(h) => h,
         Err(e) => {
             if args.json {

--- a/codex-rs/tui/src/memvid_adapter/types.rs
+++ b/codex-rs/tui/src/memvid_adapter/types.rs
@@ -1511,6 +1511,12 @@ pub struct CapsuleImportedPayload {
     /// SHA-256 hash of imported content
     #[serde(skip_serializing_if = "Option::is_none")]
     pub content_hash: Option<String>,
+    /// Mount name assigned to this import (SPEC-KIT-974 AC#7)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mount_name: Option<String>,
+    /// Whether verification passed during import (SPEC-KIT-974 AC#7)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub verification_passed: Option<bool>,
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary

Closes SPEC-KIT-974 with final enhancements for capsule export/import and GC operations.

### Changes

- **Risk-based auto-export** (`f2ec81da6`): Add `[capsule.export]` TOML config with modes `manual | risk | always` and triggers `high_risk` / `audit_handoff_required`
- **Import/GC enhancements** (`4413c03a8`):
  - AC#7: Include `mount_name` + `verification_passed` in CapsuleImported event
  - AC#8: GC opens write-capable for audit event persistence
  - Task 4: Support dual pin marker formats (`.pin` suffix + legacy)
  - Task 5: Harden rollback to not clobber registry on load failure
- **Verification tests** (`6e80ea964`): Integration tests for `[capsule.export]` TOML parsing, sidecar verification, realistic GC dry-run

### Test Plan

- [x] `cargo test -p codex-tui --lib memvid_adapter::tests` — 106 passed
- [x] `cargo test -p codex-tui --test stage0_integration_tests` — 24 passed
- [x] `cargo test -p codex-cli` — 84 passed
- [x] `cargo check -p codex-tui` — OK

### Example pipeline.toml

```toml
[capsule.export]
mode = "risk"              # manual | risk | always
high_risk = true           # triggers auto-export in risk mode
audit_handoff_required = false
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)