### PR TITLE
docs(spec-kit): reconcile Q1 spec status headers

### DIFF
--- a/docs/SPEC-KIT-971-memvid-capsule-foundation/spec.md
+++ b/docs/SPEC-KIT-971-memvid-capsule-foundation/spec.md
@@ -1,8 +1,11 @@
 # SPEC-KIT-971 — Memvid Capsule Foundation + Single-Writer Adapter
 
 **Date:** 2026-01-10\
-**Status:** DRAFT\
+**Status:** COMPLETED\
+**Completed:** 2026-01-17\
 **Owner (role):** Platform Eng
+
+> **Implementation status:** Canonical completion tracker: `codex-rs/SPEC.md` Completed (Recent).
 
 ## Summary
 

--- a/docs/SPEC-KIT-972-hybrid-retrieval-eval/spec.md
+++ b/docs/SPEC-KIT-972-hybrid-retrieval-eval/spec.md
@@ -1,8 +1,11 @@
 # SPEC-KIT-972 — Hybrid Retrieval + Explainability + Evaluation Harness
 
 **Date:** 2026-01-10\
-**Status:** DRAFT\
+**Status:** COMPLETED\
+**Completed:** 2026-01-12\
 **Owner (role):** Search/Eval Eng
+
+> **Implementation status:** Canonical completion tracker: `codex-rs/SPEC.md` Completed (Recent).
 
 ## Summary
 

--- a/docs/SPEC-KIT-973-time-travel-ui/spec.md
+++ b/docs/SPEC-KIT-973-time-travel-ui/spec.md
@@ -1,8 +1,11 @@
 # SPEC-KIT-973 — Time‑Travel UX (Timeline / As‑Of / Diff)
 
 **Date:** 2026-01-10\
-**Status:** DRAFT\
+**Status:** COMPLETED\
+**Completed:** 2026-01-19\
 **Owner (role):** TUI Eng
+
+> **Implementation status:** Canonical completion tracker: `codex-rs/SPEC.md` Completed (Recent).
 
 ## Summary
 

--- a/docs/SPEC-KIT-975-replayable-audits/spec.md
+++ b/docs/SPEC-KIT-975-replayable-audits/spec.md
@@ -1,8 +1,11 @@
 # SPEC-KIT-975 — Replayable Audits v1 (Deterministic)
 
 **Date:** 2026-01-18
-**Status:** COMPLETE
+**Status:** COMPLETED
+**Completed:** 2026-01-18
 **Owner (role):** Platform+Eval Eng
+
+> **Implementation status:** Canonical completion tracker: `codex-rs/SPEC.md` Completed (Recent).
 
 ## Summary
 

--- a/docs/SPEC-KIT-976-logic-mesh-graph/spec.md
+++ b/docs/SPEC-KIT-976-logic-mesh-graph/spec.md
@@ -1,8 +1,11 @@
 # SPEC-KIT-976 — Logic Mesh / Graph v1 (Memvid Memory Cards)
 
 **Date:** 2026-01-10\
-**Status:** DRAFT\
+**Status:** COMPLETED\
+**Completed:** 2026-01-19\
 **Owner (role):** Platform Data Eng + Librarian/Knowledge Eng
+
+> **Implementation status:** Canonical completion tracker: `codex-rs/SPEC.md` Completed (Recent).
 
 ## Summary
 

--- a/docs/SPEC-KIT-977-model-policy-v2/spec.md
+++ b/docs/SPEC-KIT-977-model-policy-v2/spec.md
@@ -1,8 +1,11 @@
 # SPEC-KIT-977 — Model Policy v2 (Lifecycle + Enforcement)
 
 **Date:** 2026-01-10\
-**Status:** DRAFT\
+**Status:** COMPLETED\
+**Completed:** 2026-01-17\
 **Owner (role):** Platform+Security Eng
+
+> **Implementation status:** Canonical completion tracker: `codex-rs/SPEC.md` Completed (Recent).
 
 ## Summary
 

--- a/docs/SPEC-KIT-978-local-reflex-sglang/spec.md
+++ b/docs/SPEC-KIT-978-local-reflex-sglang/spec.md
@@ -1,8 +1,11 @@
 # SPEC-KIT-978 — Implementer.Reflex Mode via SGLang (RTX 5090) + Bakeoff
 
 **Date:** 2026-01-18
-**Status:** COMPLETE
+**Status:** COMPLETED
+**Completed:** 2026-01-18
 **Owner (role):** Infra/LLM Eng
+
+> **Implementation status:** Canonical completion tracker: `codex-rs/SPEC.md` Completed (Recent).
 
 ## Summary
 


### PR DESCRIPTION
Sync SPEC-KIT-971/972/973/975/976/977/978 spec.md headers to match canonical completion tracker (codex-rs/SPEC.md).\n\nNo behavior changes.