### PR TITLE
fix(spec-kit): clarify headless deterministic test + guardrail exclusion

### DIFF
--- a/codex-rs/tui/src/chatwidget/spec_kit/native_guardrail.rs
+++ b/codex-rs/tui/src/chatwidget/spec_kit/native_guardrail.rs
@@ -231,6 +231,13 @@ fn validate_clean_tree(cwd: &Path) -> GuardrailCheck {
             {
                 return false;
             }
+            // Allow .speckit/ directory (auto-generated for capsule/memvid storage)
+            // Git porcelain format: "XY path" where XY is 2 status chars + space
+            // Extract the path component and check if it starts with .speckit/
+            let path = if line.len() > 3 { &line[3..] } else { line };
+            if path.starts_with(".speckit/") || path.starts_with(".speckit\\") || path == ".speckit" {
+                return false;
+            }
             true
         })
         .collect();


### PR DESCRIPTION
## Summary
- Update test comment to document gemini shim approach (replaces outdated "currently ignored" comment)
- Make PATH injection portable using `std::env::split_paths`/`join_paths`
- Tighten `.speckit/` clean-tree exclusion by parsing git porcelain format to extract path component (handles both `/` and `\` separators)
- Enable deterministic headless execute happy-path test (previously ignored due to SPEC-KIT-930)

## Implementation Details
The test uses a provider-named shim (`gemini`) to keep execution hermetic:
- `agent_tool` requires valid JSON and >=500 bytes output
- The shim provides this without requiring network or real LLM APIs
- AgentManager validates agent names (`claude|gemini|qwen|codex`) but not command behavior

## Test plan
- [x] `cargo test -p codex-cli --test speckit -- test_run_headless_execute_deterministic_happy_path` passes
- [x] `cargo test -p codex-tui --lib -- chatwidget::spec_kit::headless` passes (25 tests)
- [x] `python3 scripts/doc_lint.py` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)