### PR TITLE
feat(spec-kit): SPEC-KIT-905 CLI stage execution parity (D113/D133)

### DIFF
--- a/codex-rs/SPEC.md
+++ b/codex-rs/SPEC.md
@@ -100,9 +100,9 @@ These invariants MUST NOT be violated:
 
 ### In Progress
 
-| Spec   | Status | Owner | Next Action |
-| ------ | ------ | ----- | ----------- |
-| (none) | -      | -     | -           |
+| Spec         | Status      | Owner  | Next Action                                       |
+| ------------ | ----------- | ------ | ------------------------------------------------- |
+| SPEC-KIT-905 | In Progress | @thetu | CLI stage subcommand execution parity (D113/D133) |
 
 ### Completed (Recent)
 


### PR DESCRIPTION
## Summary

- Rename SPEC-KIT-901 → SPEC-KIT-905 (resolves collision with MCP docs spec)
- Update enum docstrings to remove "(TUI only)" and "WIP" references
- Reference D113/D133 execution parity in all stage subcommand docstrings
- Add table-driven test proving all 6 stage commands enforce NEEDS_INPUT (exit 10)
- Complete run_headless_pipeline doc with exit code 2 (HARD_FAIL)

## Test plan

- [x] `cargo test -p codex-cli --test speckit -- test_speckit_plan` (3 passing)
- [x] `cargo test -p codex-cli --test speckit -- test_all_stages_headless_require_maieutic` (1 passing)
- [x] `cargo test -p codex-tui --lib -- chatwidget::spec_kit::headless` (25 passing)
- [x] `python3 scripts/doc_lint.py` (passes with pre-existing warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)