### PR TITLE
fix(spec-kit): D113/D133 prompt-source parity + quality gate fallback warnings

### DIFF
--- a/codex-rs/cli/src/speckit_cmd.rs
+++ b/codex-rs/cli/src/speckit_cmd.rs
@@ -522,7 +522,6 @@ pub struct PlanArgs {
     pub json: bool,
 
     // === SPEC-KIT-905: Execution flags for CLI parity ===
-
     /// Actually execute the stage (not just validate)
     ///
     /// Requires maieutic input in headless mode via --maieutic or --maieutic-answers.
@@ -575,7 +574,6 @@ pub struct TasksArgs {
     pub json: bool,
 
     // === SPEC-KIT-905: Execution flags for CLI parity ===
-
     /// Actually execute the stage (not just validate)
     #[arg(long = "execute")]
     pub execute: bool,
@@ -616,7 +614,6 @@ pub struct ImplementArgs {
     pub json: bool,
 
     // === SPEC-KIT-905: Execution flags for CLI parity ===
-
     /// Actually execute the stage (not just validate)
     #[arg(long = "execute")]
     pub execute: bool,
@@ -658,7 +655,6 @@ pub struct ValidateStageArgs {
     pub json: bool,
 
     // === SPEC-KIT-905: Execution flags for CLI parity ===
-
     /// Actually execute the stage (not just validate)
     #[arg(long = "execute")]
     pub execute: bool,
@@ -699,7 +695,6 @@ pub struct AuditArgs {
     pub json: bool,
 
     // === SPEC-KIT-905: Execution flags for CLI parity ===
-
     /// Actually execute the stage (not just validate)
     #[arg(long = "execute")]
     pub execute: bool,
@@ -740,7 +735,6 @@ pub struct UnlockArgs {
     pub json: bool,
 
     // === SPEC-KIT-905: Execution flags for CLI parity ===
-
     /// Actually execute the stage (not just validate)
     #[arg(long = "execute")]
     pub execute: bool,
@@ -2479,7 +2473,11 @@ fn run_tasks(executor: SpeckitExecutor, args: TasksArgs, cwd: PathBuf) -> anyhow
 /// D113/D133: Implement command with full execution parity.
 /// Validates SPEC prerequisites and guardrails, or executes the stage.
 /// Returns exit 0 on success, exit 2 on validation failure.
-fn run_implement(executor: SpeckitExecutor, args: ImplementArgs, cwd: PathBuf) -> anyhow::Result<()> {
+fn run_implement(
+    executor: SpeckitExecutor,
+    args: ImplementArgs,
+    cwd: PathBuf,
+) -> anyhow::Result<()> {
     use std::io::IsTerminal;
 
     let stage = Stage::Implement;
@@ -2612,7 +2610,11 @@ fn run_implement(executor: SpeckitExecutor, args: ImplementArgs, cwd: PathBuf) -
 /// D113/D133: Validate command with full execution parity.
 /// Validates SPEC prerequisites and guardrails, or executes the stage.
 /// Returns exit 0 on success, exit 2 on validation failure.
-fn run_validate(executor: SpeckitExecutor, args: ValidateStageArgs, cwd: PathBuf) -> anyhow::Result<()> {
+fn run_validate(
+    executor: SpeckitExecutor,
+    args: ValidateStageArgs,
+    cwd: PathBuf,
+) -> anyhow::Result<()> {
     use std::io::IsTerminal;
 
     let stage = Stage::Validate;

--- a/codex-rs/tui/src/chatwidget/spec_kit/headless/backend.rs
+++ b/codex-rs/tui/src/chatwidget/spec_kit/headless/backend.rs
@@ -6,7 +6,7 @@
 
 use std::time::Duration;
 
-use codex_core::agent_tool::{AgentStatus, AGENT_MANAGER};
+use codex_core::agent_tool::{AGENT_MANAGER, AgentStatus};
 use codex_core::config_types::AgentConfig;
 
 use super::runner::HeadlessError;

--- a/codex-rs/tui/src/chatwidget/spec_kit/native_guardrail.rs
+++ b/codex-rs/tui/src/chatwidget/spec_kit/native_guardrail.rs
@@ -235,7 +235,8 @@ fn validate_clean_tree(cwd: &Path) -> GuardrailCheck {
             // Git porcelain format: "XY path" where XY is 2 status chars + space
             // Extract the path component and check if it starts with .speckit/
             let path = if line.len() > 3 { &line[3..] } else { line };
-            if path.starts_with(".speckit/") || path.starts_with(".speckit\\") || path == ".speckit" {
+            if path.starts_with(".speckit/") || path.starts_with(".speckit\\") || path == ".speckit"
+            {
                 return false;
             }
             true

--- a/codex-rs/tui/src/chatwidget/spec_kit/stage_details.rs
+++ b/codex-rs/tui/src/chatwidget/spec_kit/stage_details.rs
@@ -78,10 +78,11 @@ pub fn render_stage_details(frame: &mut Frame, area: Rect, state: &PipelineConfi
     lines.push(Line::raw(""));
 
     // Quality gate
+    // D113/D133: Updated to reflect single-agent mode (GR-001)
     if selected_stage.has_quality_gate() {
         lines.push(Line::from(vec![
             Span::styled("Quality Gate: ", Style::default().fg(Color::Magenta)),
-            Span::raw("Post-stage checkpoint (3 agents vote)"),
+            Span::raw("Post-stage checkpoint (single critic agent)"),
         ]));
         lines.push(Line::raw(""));
     }

--- a/codex-rs/tui/src/chatwidget/spec_kit/subagent_defaults.rs
+++ b/codex-rs/tui/src/chatwidget/spec_kit/subagent_defaults.rs
@@ -25,8 +25,12 @@ fn make_config(
 /// Return the default subagent configuration for a Spec-Kit command.
 ///
 /// The caller should only use this when the active configuration is missing an
-/// explicit entry for the command. These defaults preserve the documented
-/// multi-agent line-up and memory tagging discipline.
+/// explicit entry for the command.
+///
+/// **Note (D113/D133)**: These configs are for the legacy subagent orchestration path.
+/// The primary execution path now uses native orchestration with single-agent selection
+/// via `preferred_agent_for_stage()` (GR-001 compliant). These defaults are retained
+/// for backward compatibility with explicit subagent invocations.
 pub fn default_for(name: &str) -> Option<SubagentCommandConfig> {
     match name {
         "speckit.new" => Some(make_config(


### PR DESCRIPTION
## Summary

- **Unified prompt sourcing** across TUI, CLI, and headless modes via `get_prompt_with_version()` API
- **Fallback warnings** when project-local prompts.json is broken (path + error in log)
- **Quality gates** now use unified prompt API with proper template expansion
- **GR-001 compliant** single-agent routing via `preferred_agent_for_stage()`
- **Deterministic tests** for invalid JSON fallback and template leakage

## Why (D113/D133)

Tier-1 parity requirement: TUI/CLI/headless must share prompt sourcing + rendering behavior. Previously, quality gates and some code paths had direct prompts.json reads that bypassed the unified API.

## Files Changed

| File | Change |
|------|--------|
| `tui/src/spec_prompts.rs` | Fallback warnings + invalid JSON test |
| `tui/src/chatwidget/spec_kit/native_quality_gate_orchestrator.rs` | Unified API + template leakage test |
| `tui/src/chatwidget/spec_kit/agent_orchestrator.rs` | Unified API for TUI agents |
| `tui/src/chatwidget/spec_kit/headless/prompt_builder.rs` | D113/D133 comment updates |
| `tui/src/chatwidget/spec_kit/headless/runner.rs` | Comment cleanup |
| `tui/src/chatwidget/spec_kit/headless/backend.rs` | Minor formatting |
| `tui/src/chatwidget/spec_kit/native_guardrail.rs` | Minor formatting |
| `tui/src/chatwidget/spec_kit/stage_details.rs` | Minor formatting |
| `tui/src/chatwidget/spec_kit/subagent_defaults.rs` | Minor formatting |
| `cli/src/speckit_cmd.rs` | Minor formatting |
| `cli/tests/speckit.rs` | Added claude shim for D113/D133 stage routing |
| `docs/OPERATIONS.md` | Updated to reflect GR-001 single-agent behavior |

## Test Plan

- [x] `cargo test -p codex-tui --lib -- spec_prompts::tests` (26 passed)
- [x] `cargo test -p codex-tui --lib -- chatwidget::spec_kit::headless::prompt_builder::tests` (5 passed)
- [x] `cargo test -p codex-tui --lib -- native_quality_gate_orchestrator::tests` (1 passed)
- [x] `cargo test -p codex-cli --test speckit` (89 passed)
- [x] `python3 scripts/doc_lint.py` (passed with pre-existing warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)