### PR TITLE
fix(spec-kit): MAINT-17 restore hermetic speckit tests under GPT defaults

### DIFF
--- a/codex-rs/SPEC.md
+++ b/codex-rs/SPEC.md
@@ -115,6 +115,7 @@ These invariants MUST NOT be violated:
 | Spec                | Completion Date | Key Deliverables                                                                              |
 | ------------------- | --------------- | --------------------------------------------------------------------------------------------- |
 | SPEC-KIT-983        | 2026-02-01      | Stage→agent defaults modal + root-only persistence with user-visible errors                   |
+| MAINT-17            | 2026-02-01      | Fix codex-cli hermetic speckit tests to set \[speckit.stage\_agents] under GPT defaults       |
 | MAINT-16            | 2026-01-31      | Headless ACE init + runtime-safe fetch + git repo-root parity (D113/D133)                     |
 | SPEC-KIT-982        | 2026-01-31      | ACE + maieutic injection into per-agent prompts via unified builder (D113/D133 parity)        |
 | SPEC-KIT-981        | 2026-01-31      | Config-driven stage→agent mapping with GPT-5.2 defaults, TUI/headless parity                  |

--- a/codex-rs/cli/tests/speckit.rs
+++ b/codex-rs/cli/tests/speckit.rs
@@ -4087,7 +4087,7 @@ EOF
     }
 
     // Create config.toml with both gemini and claude agents pointing to our shims
-    // D113/D133: Plan uses gemini, Tasks uses claude (preferred_agent_for_stage)
+    // Hermetic tests pin stage routing via [speckit.stage_agents] to shim agents.
     let config_path = codex_home.path().join("config.toml");
     fs::write(
         &config_path,
@@ -4103,6 +4103,10 @@ name = "claude"
 command = "claude"
 args = []
 enabled = true
+
+[speckit.stage_agents]
+plan = "gemini"
+tasks = "claude"
 "#,
     )?;
 
@@ -4306,6 +4310,7 @@ EOF
     }
 
     // Create config.toml with gemini agent
+    // Hermetic tests pin stage routing via [speckit.stage_agents] to shim agents.
     let config_path = codex_home.path().join("config.toml");
     fs::write(
         &config_path,
@@ -4315,6 +4320,9 @@ name = "gemini"
 command = "gemini"
 args = []
 enabled = true
+
+[speckit.stage_agents]
+plan = "gemini"
 "#,
     )?;
 


### PR DESCRIPTION
## Summary

- Fix hermetic CLI tests (`test_run_headless_execute_deterministic_happy_path`, `test_speckit_plan_execute_headless_happy_path`) that failed after SPEC-KIT-981 changed `preferred_agent_for_stage()` defaults to GPT
- Add explicit `[speckit.stage_agents]` overrides to test config.toml files to pin routing to available shim agents
- Update stale comment to reflect explicit config pinning approach

## Test plan

- [x] `cargo test -p codex-cli --test speckit test_run_headless_execute_deterministic_happy_path` passes
- [x] `cargo test -p codex-cli --test speckit test_speckit_plan_execute_headless_happy_path` passes
- [x] `cargo test -p codex-cli --test speckit test_run_with_execute_invokes_headless_runner` passes
- [x] Full speckit test suite passes (89 passed, 3 ignored)
- [x] `cargo fmt --all -- --check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)