### PR TITLE
docs(workflow): require DEV_BRIEF.md (Tier-1 truth anchor)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -9,6 +9,13 @@
 echo "🔍 Running pre-commit checks..."
 echo ""
 
+# === Tier-1 anchor: DEV_BRIEF.md required ===
+if [[ ! -s "DEV_BRIEF.md" ]]; then
+    echo "❌ DEV_BRIEF.md is missing or empty"
+    echo "Create it before committing. See: scripts/README_doc_lint.md"
+    exit 1
+fi
+
 # === SPEC-KIT-964: Config isolation validation ===
 # Always run, regardless of what files changed
 if [[ -f "scripts/validate-config-isolation.sh" ]]; then

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,7 @@ Project instructions for AI agents (Claude Code, code TUI, Gemini, etc.)
 ## Commands
 
 ### Build
+
 ```bash
 ~/code/build-fast.sh              # Fast build (dev-fast profile)
 ~/code/build-fast.sh run          # Build and run TUI
@@ -15,6 +16,7 @@ PROFILE=release ~/code/build-fast.sh   # Release build
 ```
 
 ### Test
+
 ```bash
 cd codex-rs
 cargo test -p codex-core                           # All core tests
@@ -23,6 +25,7 @@ cargo test -p codex-core -- --ignored              # Include ignored
 ```
 
 ### Lint & Validate
+
 ```bash
 cd codex-rs
 cargo fmt --all -- --check
@@ -31,6 +34,7 @@ cargo build --workspace --all-features
 ```
 
 ### Spec-Kit Commands
+
 ```bash
 /speckit.new <description>        # Create new SPEC (instant, free)
 /speckit.project rust <name>      # Scaffold project with spec-kit
@@ -41,10 +45,10 @@ cargo build --workspace --all-features
 
 ## Code Style
 
-- **Commits**: Conventional format - `feat(scope):`, `fix(scope):`, `docs(scope):`
-- **Branches**: Feature branches only, never commit directly to main
-- **Pre-commit**: Auto-runs fmt, clippy, doc validation via `.githooks/`
-- **Setup hooks**: `bash scripts/setup-hooks.sh` (one-time)
+* **Commits**: Conventional format - `feat(scope):`, `fix(scope):`, `docs(scope):`
+* **Branches**: Feature branches only, never commit directly to main
+* **Pre-commit**: Auto-runs fmt, clippy, doc validation via `.githooks/`
+* **Setup hooks**: `bash scripts/setup-hooks.sh` (one-time)
 
 ## Project Structure
 
@@ -62,19 +66,25 @@ docs/
 SPEC.md                      # Task tracking (single source of truth)
 ```
 
+## Required Files
+
+* **DEV\_BRIEF.md**: Tier-1 truth anchor (must exist and be non-empty)
+  * Update at session start with current focus/constraints
+  * Enforced by pre-commit hook (hard block) and doc\_lint
+
 ## Testing Notes
 
-- **Test location**: Run from `codex-rs/` directory
-- **Current status**: 31 passing, 12 ignored in codex-core
-- **Ignored tests**: Have documented blockers (fork divergences)
-- **Don't use**: `cargo build -p codex-tui` directly (use build script)
+* **Test location**: Run from `codex-rs/` directory
+* **Current status**: 31 passing, 12 ignored in codex-core
+* **Ignored tests**: Have documented blockers (fork divergences)
+* **Don't use**: `cargo build -p codex-tui` directly (use build script)
 
 ## Known Quirks
 
-- HAL secrets: Set `SPEC_OPS_HAL_SKIP=1` if `HAL_SECRET_KAVEDARR_API_KEY` unavailable
-- Evidence limit: 25 MB soft limit per SPEC, monitor with `/spec-evidence-stats`
-- Dirty tree: Guardrails require clean tree unless `SPEC_OPS_ALLOW_DIRTY=1`
-- Config isolation: Templates resolve `./templates/` → embedded only (no global)
+* HAL secrets: Set `SPEC_OPS_HAL_SKIP=1` if `HAL_SECRET_KAVEDARR_API_KEY` unavailable
+* Evidence limit: 25 MB soft limit per SPEC, monitor with `/spec-evidence-stats`
+* Dirty tree: Guardrails require clean tree unless `SPEC_OPS_ALLOW_DIRTY=1`
+* Config isolation: Templates resolve `./templates/` → embedded only (no global)
 
 ## Local Memory Integration
 
@@ -82,20 +92,22 @@ SPEC.md                      # Task tracking (single source of truth)
 
 ### Golden Path vs Manual
 
-| Mode | When | Memory Handling |
-|------|------|-----------------|
-| **`/speckit.auto`** | Primary workflow | Stage0 orchestrates memory recall + Tier2 (NotebookLM) |
-| **Ad-hoc work** | Debugging, exploration | Use `lm` commands manually (below) |
+| Mode                | When                   | Memory Handling                                        |
+| ------------------- | ---------------------- | ------------------------------------------------------ |
+| **`/speckit.auto`** | Primary workflow       | Stage0 orchestrates memory recall + Tier2 (NotebookLM) |
+| **Ad-hoc work**     | Debugging, exploration | Use `lm` commands manually (below)                     |
 
 ### Manual Commands (Non-Golden-Path Only)
 
 **Before proposing changes** (if NOT using `/speckit.auto`):
+
 ```bash
 lm recall "<task keywords>" --limit 5
 lm domain  # Verify domain resolution
 ```
 
 **After significant work** (importance >= 8 only):
+
 ```bash
 lm remember "<insight>" --type <TYPE> --importance 8 --tags "component:..."
 ```
@@ -106,28 +118,28 @@ lm remember "<insight>" --type <TYPE> --importance 8 --tags "component:..."
 
 ## Git
 
-- Default branch: **main**
+* Default branch: **main**
 
 ## Extended Documentation
 
 For detailed guidance beyond commands and structure:
 
-| Topic | Document |
-|-------|----------|
-| Behavioral rules | `docs/OPERATIONAL-PLAYBOOK.md` |
-| Model-specific reasoning | `docs/MODEL-GUIDANCE.md` |
+| Topic                    | Document                                    |
+| ------------------------ | ------------------------------------------- |
+| Behavioral rules         | `docs/OPERATIONAL-PLAYBOOK.md`              |
+| Model-specific reasoning | `docs/MODEL-GUIDANCE.md`                    |
 | Multi-agent architecture | `docs/spec-kit/MULTI-AGENT-ARCHITECTURE.md` |
-| Memory policy | `MEMORY-POLICY.md` |
-| Project charter | `memory/constitution.md` |
+| Memory policy            | `MEMORY-POLICY.md`                          |
+| Project charter          | `memory/constitution.md`                    |
 
 ## Policy Pointers
 
-- **Authoritative policy**: `docs/MODEL-POLICY.md` (v1.0.0)
-- **Guardrails**: GR-001 through GR-013
-- **No consensus by default** — single-owner pipeline (Architect → Implementer → Judge)
-- **Routing thresholds**: Architect escalation at `confidence < 0.75`, Implementer escalation after 2 failed loops
-- **Kimi/DeepSeek**: escalation-only (never default path)
+* **Authoritative policy**: `docs/MODEL-POLICY.md` (v1.0.0)
+* **Guardrails**: GR-001 through GR-013
+* **No consensus by default** — single-owner pipeline (Architect → Implementer → Judge)
+* **Routing thresholds**: Architect escalation at `confidence < 0.75`, Implementer escalation after 2 failed loops
+* **Kimi/DeepSeek**: escalation-only (never default path)
 
----
+***
 
 Back to [Key Docs](docs/KEY_DOCS.md)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,7 @@ Project instructions for AI agents (Claude Code, code TUI, Gemini, etc.)
 ## Commands
 
 ### Build
+
 ```bash
 ~/code/build-fast.sh              # Fast build (dev-fast profile)
 ~/code/build-fast.sh run          # Build and run TUI
@@ -15,6 +16,7 @@ PROFILE=release ~/code/build-fast.sh   # Release build
 ```
 
 ### Test
+
 ```bash
 cd codex-rs
 cargo test -p codex-core                           # All core tests
@@ -23,6 +25,7 @@ cargo test -p codex-core -- --ignored              # Include ignored
 ```
 
 ### Lint & Validate
+
 ```bash
 cd codex-rs
 cargo fmt --all -- --check
@@ -31,6 +34,7 @@ cargo build --workspace --all-features
 ```
 
 ### Spec-Kit Commands
+
 ```bash
 /speckit.new <description>        # Create new SPEC (instant, free)
 /speckit.project rust <name>      # Scaffold project with spec-kit
@@ -41,10 +45,10 @@ cargo build --workspace --all-features
 
 ## Code Style
 
-- **Commits**: Conventional format - `feat(scope):`, `fix(scope):`, `docs(scope):`
-- **Branches**: Feature branches only, never commit directly to main
-- **Pre-commit**: Auto-runs fmt, clippy, doc validation via `.githooks/`
-- **Setup hooks**: `bash scripts/setup-hooks.sh` (one-time)
+* **Commits**: Conventional format - `feat(scope):`, `fix(scope):`, `docs(scope):`
+* **Branches**: Feature branches only, never commit directly to main
+* **Pre-commit**: Auto-runs fmt, clippy, doc validation via `.githooks/`
+* **Setup hooks**: `bash scripts/setup-hooks.sh` (one-time)
 
 ## Project Structure
 
@@ -62,19 +66,25 @@ docs/
 SPEC.md                      # Task tracking (single source of truth)
 ```
 
+## Required Files
+
+* **DEV\_BRIEF.md**: Tier-1 truth anchor (must exist and be non-empty)
+  * Update at session start with current focus/constraints
+  * Enforced by pre-commit hook (hard block) and doc\_lint
+
 ## Testing Notes
 
-- **Test location**: Run from `codex-rs/` directory
-- **Current status**: 31 passing, 12 ignored in codex-core
-- **Ignored tests**: Have documented blockers (fork divergences)
-- **Don't use**: `cargo build -p codex-tui` directly (use build script)
+* **Test location**: Run from `codex-rs/` directory
+* **Current status**: 31 passing, 12 ignored in codex-core
+* **Ignored tests**: Have documented blockers (fork divergences)
+* **Don't use**: `cargo build -p codex-tui` directly (use build script)
 
 ## Known Quirks
 
-- HAL secrets: Set `SPEC_OPS_HAL_SKIP=1` if `HAL_SECRET_KAVEDARR_API_KEY` unavailable
-- Evidence limit: 25 MB soft limit per SPEC, monitor with `/spec-evidence-stats`
-- Dirty tree: Guardrails require clean tree unless `SPEC_OPS_ALLOW_DIRTY=1`
-- Config isolation: Templates resolve `./templates/` → embedded only (no global)
+* HAL secrets: Set `SPEC_OPS_HAL_SKIP=1` if `HAL_SECRET_KAVEDARR_API_KEY` unavailable
+* Evidence limit: 25 MB soft limit per SPEC, monitor with `/spec-evidence-stats`
+* Dirty tree: Guardrails require clean tree unless `SPEC_OPS_ALLOW_DIRTY=1`
+* Config isolation: Templates resolve `./templates/` → embedded only (no global)
 
 ## Local Memory Integration
 
@@ -82,20 +92,22 @@ SPEC.md                      # Task tracking (single source of truth)
 
 ### Golden Path vs Manual
 
-| Mode | When | Memory Handling |
-|------|------|-----------------|
-| **`/speckit.auto`** | Primary workflow | Stage0 orchestrates memory recall + Tier2 (NotebookLM) |
-| **Ad-hoc work** | Debugging, exploration | Use `lm` commands manually (below) |
+| Mode                | When                   | Memory Handling                                        |
+| ------------------- | ---------------------- | ------------------------------------------------------ |
+| **`/speckit.auto`** | Primary workflow       | Stage0 orchestrates memory recall + Tier2 (NotebookLM) |
+| **Ad-hoc work**     | Debugging, exploration | Use `lm` commands manually (below)                     |
 
 ### Manual Commands (Non-Golden-Path Only)
 
 **Before proposing changes** (if NOT using `/speckit.auto`):
+
 ```bash
 lm recall "<task keywords>" --limit 5
 lm domain  # Verify domain resolution
 ```
 
 **After significant work** (importance >= 8 only):
+
 ```bash
 lm remember "<insight>" --type <TYPE> --importance 8 --tags "component:..."
 ```
@@ -106,28 +118,28 @@ lm remember "<insight>" --type <TYPE> --importance 8 --tags "component:..."
 
 ## Git
 
-- Default branch: **main**
+* Default branch: **main**
 
 ## Extended Documentation
 
 For detailed guidance beyond commands and structure:
 
-| Topic | Document |
-|-------|----------|
-| Behavioral rules | `docs/OPERATIONAL-PLAYBOOK.md` |
-| Model-specific reasoning | `docs/MODEL-GUIDANCE.md` |
+| Topic                    | Document                                    |
+| ------------------------ | ------------------------------------------- |
+| Behavioral rules         | `docs/OPERATIONAL-PLAYBOOK.md`              |
+| Model-specific reasoning | `docs/MODEL-GUIDANCE.md`                    |
 | Multi-agent architecture | `docs/spec-kit/MULTI-AGENT-ARCHITECTURE.md` |
-| Memory policy | `MEMORY-POLICY.md` |
-| Project charter | `memory/constitution.md` |
+| Memory policy            | `MEMORY-POLICY.md`                          |
+| Project charter          | `memory/constitution.md`                    |
 
 ## Policy Pointers
 
-- **Authoritative policy**: `docs/MODEL-POLICY.md` (v1.0.0)
-- **Guardrails**: GR-001 through GR-013
-- **No consensus by default** — single-owner pipeline (Architect → Implementer → Judge)
-- **Routing thresholds**: Architect escalation at `confidence < 0.75`, Implementer escalation after 2 failed loops
-- **Kimi/DeepSeek**: escalation-only (never default path)
+* **Authoritative policy**: `docs/MODEL-POLICY.md` (v1.0.0)
+* **Guardrails**: GR-001 through GR-013
+* **No consensus by default** — single-owner pipeline (Architect → Implementer → Judge)
+* **Routing thresholds**: Architect escalation at `confidence < 0.75`, Implementer escalation after 2 failed loops
+* **Kimi/DeepSeek**: escalation-only (never default path)
 
----
+***
 
 Back to [Key Docs](docs/KEY_DOCS.md)

--- a/DEV_BRIEF.md
+++ b/DEV_BRIEF.md
@@ -1,0 +1,25 @@
+# DEV\_BRIEF.md
+
+> **Tier-1 Truth Anchor** — Required for every session. Update before starting work.
+
+**Last Updated**: 2026-02-03
+
+## Current Focus
+
+<!-- What are we working on right now? -->
+
+## Scope / Constraints
+
+* Local-memory: CLI-only (no MCP) — see [MEMORY-POLICY.md](MEMORY-POLICY.md)
+* Historical docs under `docs/SPEC-KIT-*` are frozen
+
+## Open Questions
+
+<!-- Unresolved decisions or clarifications needed -->
+
+## Verification
+
+```bash
+python3 scripts/doc_lint.py      # Must pass
+bash .githooks/pre-commit        # Must pass
+```

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -8,6 +8,7 @@ Project instructions for AI agents (Claude Code, code TUI, Gemini, etc.)
 ## Commands
 
 ### Build
+
 ```bash
 ~/code/build-fast.sh              # Fast build (dev-fast profile)
 ~/code/build-fast.sh run          # Build and run TUI
@@ -15,6 +16,7 @@ PROFILE=release ~/code/build-fast.sh   # Release build
 ```
 
 ### Test
+
 ```bash
 cd codex-rs
 cargo test -p codex-core                           # All core tests
@@ -23,6 +25,7 @@ cargo test -p codex-core -- --ignored              # Include ignored
 ```
 
 ### Lint & Validate
+
 ```bash
 cd codex-rs
 cargo fmt --all -- --check
@@ -31,6 +34,7 @@ cargo build --workspace --all-features
 ```
 
 ### Spec-Kit Commands
+
 ```bash
 /speckit.new <description>        # Create new SPEC (instant, free)
 /speckit.project rust <name>      # Scaffold project with spec-kit
@@ -41,10 +45,10 @@ cargo build --workspace --all-features
 
 ## Code Style
 
-- **Commits**: Conventional format - `feat(scope):`, `fix(scope):`, `docs(scope):`
-- **Branches**: Feature branches only, never commit directly to main
-- **Pre-commit**: Auto-runs fmt, clippy, doc validation via `.githooks/`
-- **Setup hooks**: `bash scripts/setup-hooks.sh` (one-time)
+* **Commits**: Conventional format - `feat(scope):`, `fix(scope):`, `docs(scope):`
+* **Branches**: Feature branches only, never commit directly to main
+* **Pre-commit**: Auto-runs fmt, clippy, doc validation via `.githooks/`
+* **Setup hooks**: `bash scripts/setup-hooks.sh` (one-time)
 
 ## Project Structure
 
@@ -62,19 +66,25 @@ docs/
 SPEC.md                      # Task tracking (single source of truth)
 ```
 
+## Required Files
+
+* **DEV\_BRIEF.md**: Tier-1 truth anchor (must exist and be non-empty)
+  * Update at session start with current focus/constraints
+  * Enforced by pre-commit hook (hard block) and doc\_lint
+
 ## Testing Notes
 
-- **Test location**: Run from `codex-rs/` directory
-- **Current status**: 31 passing, 12 ignored in codex-core
-- **Ignored tests**: Have documented blockers (fork divergences)
-- **Don't use**: `cargo build -p codex-tui` directly (use build script)
+* **Test location**: Run from `codex-rs/` directory
+* **Current status**: 31 passing, 12 ignored in codex-core
+* **Ignored tests**: Have documented blockers (fork divergences)
+* **Don't use**: `cargo build -p codex-tui` directly (use build script)
 
 ## Known Quirks
 
-- HAL secrets: Set `SPEC_OPS_HAL_SKIP=1` if `HAL_SECRET_KAVEDARR_API_KEY` unavailable
-- Evidence limit: 25 MB soft limit per SPEC, monitor with `/spec-evidence-stats`
-- Dirty tree: Guardrails require clean tree unless `SPEC_OPS_ALLOW_DIRTY=1`
-- Config isolation: Templates resolve `./templates/` → embedded only (no global)
+* HAL secrets: Set `SPEC_OPS_HAL_SKIP=1` if `HAL_SECRET_KAVEDARR_API_KEY` unavailable
+* Evidence limit: 25 MB soft limit per SPEC, monitor with `/spec-evidence-stats`
+* Dirty tree: Guardrails require clean tree unless `SPEC_OPS_ALLOW_DIRTY=1`
+* Config isolation: Templates resolve `./templates/` → embedded only (no global)
 
 ## Local Memory Integration
 
@@ -82,20 +92,22 @@ SPEC.md                      # Task tracking (single source of truth)
 
 ### Golden Path vs Manual
 
-| Mode | When | Memory Handling |
-|------|------|-----------------|
-| **`/speckit.auto`** | Primary workflow | Stage0 orchestrates memory recall + Tier2 (NotebookLM) |
-| **Ad-hoc work** | Debugging, exploration | Use `lm` commands manually (below) |
+| Mode                | When                   | Memory Handling                                        |
+| ------------------- | ---------------------- | ------------------------------------------------------ |
+| **`/speckit.auto`** | Primary workflow       | Stage0 orchestrates memory recall + Tier2 (NotebookLM) |
+| **Ad-hoc work**     | Debugging, exploration | Use `lm` commands manually (below)                     |
 
 ### Manual Commands (Non-Golden-Path Only)
 
 **Before proposing changes** (if NOT using `/speckit.auto`):
+
 ```bash
 lm recall "<task keywords>" --limit 5
 lm domain  # Verify domain resolution
 ```
 
 **After significant work** (importance >= 8 only):
+
 ```bash
 lm remember "<insight>" --type <TYPE> --importance 8 --tags "component:..."
 ```
@@ -106,28 +118,28 @@ lm remember "<insight>" --type <TYPE> --importance 8 --tags "component:..."
 
 ## Git
 
-- Default branch: **main**
+* Default branch: **main**
 
 ## Extended Documentation
 
 For detailed guidance beyond commands and structure:
 
-| Topic | Document |
-|-------|----------|
-| Behavioral rules | `docs/OPERATIONAL-PLAYBOOK.md` |
-| Model-specific reasoning | `docs/MODEL-GUIDANCE.md` |
+| Topic                    | Document                                    |
+| ------------------------ | ------------------------------------------- |
+| Behavioral rules         | `docs/OPERATIONAL-PLAYBOOK.md`              |
+| Model-specific reasoning | `docs/MODEL-GUIDANCE.md`                    |
 | Multi-agent architecture | `docs/spec-kit/MULTI-AGENT-ARCHITECTURE.md` |
-| Memory policy | `MEMORY-POLICY.md` |
-| Project charter | `memory/constitution.md` |
+| Memory policy            | `MEMORY-POLICY.md`                          |
+| Project charter          | `memory/constitution.md`                    |
 
 ## Policy Pointers
 
-- **Authoritative policy**: `docs/MODEL-POLICY.md` (v1.0.0)
-- **Guardrails**: GR-001 through GR-013
-- **No consensus by default** — single-owner pipeline (Architect → Implementer → Judge)
-- **Routing thresholds**: Architect escalation at `confidence < 0.75`, Implementer escalation after 2 failed loops
-- **Kimi/DeepSeek**: escalation-only (never default path)
+* **Authoritative policy**: `docs/MODEL-POLICY.md` (v1.0.0)
+* **Guardrails**: GR-001 through GR-013
+* **No consensus by default** — single-owner pipeline (Architect → Implementer → Judge)
+* **Routing thresholds**: Architect escalation at `confidence < 0.75`, Implementer escalation after 2 failed loops
+* **Kimi/DeepSeek**: escalation-only (never default path)
 
----
+***
 
 Back to [Key Docs](docs/KEY_DOCS.md)

--- a/codex-rs/scripts/doc_lint.py
+++ b/codex-rs/scripts/doc_lint.py
@@ -37,6 +37,7 @@ from typing import Optional
 REPO_ROOT = Path(__file__).parent.parent.parent  # codex-rs/scripts/ -> codex-rs/ -> repo root
 
 REQUIRED_FILES = {
+    "DEV_BRIEF.md": "Tier-1 dev brief (required)",
     "SPEC.md": "Root task tracking and docs contract",
     "docs/PROGRAM.md": "Active specs, dependency DAG, sequencing gates",
     "docs/DECISIONS.md": "Locked decisions register (D1-D134)",


### PR DESCRIPTION
## Summary
- Add `DEV_BRIEF.md` template at repo root as Tier-1 truth anchor
- Add to `doc_lint.py` REQUIRED_FILES for validation
- Add hard block in pre-commit hook (missing/empty → exit 1)
- Document requirement in CLAUDE.md, AGENTS.md, GEMINI.md

## Test plan
- [x] `python3 scripts/doc_lint.py` passes
- [x] `bash .githooks/pre-commit` passes
- [x] Instruction file parity maintained

🤖 Generated with [Claude Code](https://claude.com/claude-code)