### PR TITLE
docs: update /speckit.new syntax to <AREA> <description>

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,7 @@ cargo build --workspace --all-features
 ### Spec-Kit Commands
 
 ```bash
-/speckit.new <description>        # Create new SPEC (instant, free)
+/speckit.new <AREA> <description> # Create new SPEC (instant, free)
 /speckit.project rust <name>      # Scaffold project with spec-kit
 /speckit.auto SPEC-ID             # Full 6-stage pipeline (~$2.70)
 /speckit.status SPEC-ID           # Check SPEC status

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,7 @@ cargo build --workspace --all-features
 ### Spec-Kit Commands
 
 ```bash
-/speckit.new <description>        # Create new SPEC (instant, free)
+/speckit.new <AREA> <description> # Create new SPEC (instant, free)
 /speckit.project rust <name>      # Scaffold project with spec-kit
 /speckit.auto SPEC-ID             # Full 6-stage pipeline (~$2.70)
 /speckit.status SPEC-ID           # Check SPEC status

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -36,7 +36,7 @@ cargo build --workspace --all-features
 ### Spec-Kit Commands
 
 ```bash
-/speckit.new <description>        # Create new SPEC (instant, free)
+/speckit.new <AREA> <description> # Create new SPEC (instant, free)
 /speckit.project rust <name>      # Scaffold project with spec-kit
 /speckit.auto SPEC-ID             # Full 6-stage pipeline (~$2.70)
 /speckit.status SPEC-ID           # Check SPEC status

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Planner
 
-&ensp;
+ 
 
 <p align="center">
   <img src="docs/logo.png" alt="Planner Logo" width="400">
 </p>
 
-&ensp;
+ 
 
 Planner is a terminal TUI focused on **Spec-Kit workflows** (slash commands under `/speckit.*`).
 
@@ -18,9 +18,9 @@ Spec-Kit is a structured workflow for turning a feature description into a SPEC 
 
 ## What Problems It Solves
 
-- Scaffold new projects with Spec-Kit workflow files
-- Create SPEC directories and stage artifacts (spec/plan/tasks)
-- Run an end-to-end pipeline with evidence captured under `docs/`
+* Scaffold new projects with Spec-Kit workflow files
+* Create SPEC directories and stage artifacts (spec/plan/tasks)
+* Run an end-to-end pipeline with evidence captured under `docs/`
 
 ## Quickstart
 
@@ -33,28 +33,28 @@ In the TUI:
 
 ```text
 /speckit.project rust my-rust-lib   (optional)
-/speckit.new <feature description>
+/speckit.new <AREA> <description>
 /speckit.auto SPEC-KIT-###
 ```
 
 ## How It Works
 
-- Spec-Kit is exposed as `/speckit.*` slash commands.
-- The implementation lives in `codex-rs/tui/src/chatwidget/spec_kit/` (TUI + orchestration) and `codex-rs/spec-kit/` (shared library).
+* Spec-Kit is exposed as `/speckit.*` slash commands.
+* The implementation lives in `codex-rs/tui/src/chatwidget/spec_kit/` (TUI + orchestration) and `codex-rs/spec-kit/` (shared library).
 
 ## Safety Model
 
-- Removed legacy commands (`/plan`, `/solve`, `/code`) show a migration message and do not run tools.
+* Removed legacy commands (`/plan`, `/solve`, `/code`) show a migration message and do not run tools.
 
 ## Configuration
 
-- See `docs/config.md`.
+* See `docs/config.md`.
 
 ## Documentation
 
-- Start here: `docs/KEY_DOCS.md`
-- Vision: `docs/VISION.md`
-- Removed commands: `docs/DEPRECATIONS.md`
+* Start here: `docs/KEY_DOCS.md`
+* Vision: `docs/VISION.md`
+* Removed commands: `docs/DEPRECATIONS.md`
 
 ## Development
 

--- a/codex-rs/stage0/src/project_intel/snapshot.rs
+++ b/codex-rs/stage0/src/project_intel/snapshot.rs
@@ -326,7 +326,7 @@ impl ProjectSnapshotBuilder {
             },
             WorkflowSummary {
                 name: "speckit.new".to_string(),
-                command: "/speckit.new <description>".to_string(),
+                command: "/speckit.new <AREA> <description>".to_string(),
                 description: "Create new SPEC with guided questions".to_string(),
                 stages: vec![
                     "Project detection".to_string(),

--- a/docs/spec-kit/COMMANDS.md
+++ b/docs/spec-kit/COMMANDS.md
@@ -10,7 +10,7 @@ Interactive commands available in the TUI chat interface.
 
 | Command                             | Aliases           | Description                           | SPEC             |
 | ----------------------------------- | ----------------- | ------------------------------------- | ---------------- |
-| `/speckit.new <desc>`               | `/spec.new`       | Create new SPEC with intake questions | -                |
+| `/speckit.new <AREA> <desc>`        | `/spec.new`       | Create new SPEC with intake questions | -                |
 | `/speckit.projectnew <type> <name>` | -                 | Create project scaffold with vision   | SPEC-KIT-960     |
 | `/speckit.capsule <subcommand>`     | `/capsule.doctor` | Capsule management                    | SPEC-KIT-971/974 |
 | `/speckit.projections rebuild`      | -                 | Regenerate filesystem from SoR        | WP-A             |

--- a/product-requirements.md
+++ b/product-requirements.md
@@ -19,7 +19,7 @@
 **Core Workflow:**
 
 ```
-/speckit.new <description>
+/speckit.new <AREA> <description>
   → Multi-agent PRD creation with templates
   → SPEC-ID generation
   → Consistent structure (55% faster)

--- a/templates/AGENTS-template.md
+++ b/templates/AGENTS-template.md
@@ -40,7 +40,7 @@ lm remember "<insight>" --type <TYPE> --importance 8 --tags "component:..."
 
 This project uses spec-kit for structured development:
 
-* `/speckit.new <description>` - Create new SPEC
+* `/speckit.new <AREA> <description>` - Create new SPEC
 * `/speckit.auto SPEC-ID` - Full automation pipeline (Stage0 handles memory)
 * `/speckit.status SPEC-ID` - Check progress
 

--- a/templates/CLAUDE-template.md
+++ b/templates/CLAUDE-template.md
@@ -40,7 +40,7 @@ lm remember "<insight>" --type <TYPE> --importance 8 --tags "component:..."
 
 This project uses spec-kit for structured development:
 
-* `/speckit.new <description>` - Create new SPEC
+* `/speckit.new <AREA> <description>` - Create new SPEC
 * `/speckit.auto SPEC-ID` - Full automation pipeline (Stage0 handles memory)
 * `/speckit.status SPEC-ID` - Check progress
 

--- a/templates/GEMINI-template.md
+++ b/templates/GEMINI-template.md
@@ -40,7 +40,7 @@ lm remember "<insight>" --type <TYPE> --importance 8 --tags "component:..."
 
 This project uses spec-kit for structured development:
 
-* `/speckit.new <description>` - Create new SPEC
+* `/speckit.new <AREA> <description>` - Create new SPEC
 * `/speckit.auto SPEC-ID` - Full automation pipeline (Stage0 handles memory)
 * `/speckit.status SPEC-ID` - Check progress
 


### PR DESCRIPTION
## Summary
Update `/speckit.new` command syntax from `<description>` to `<AREA> <description>` in all current docs and templates.

## Files Updated
- `CLAUDE.md`, `AGENTS.md`, `GEMINI.md`
- `README.md`, `product-requirements.md`
- `docs/spec-kit/COMMANDS.md`
- `templates/*-template.md`
- `codex-rs/stage0/src/project_intel/snapshot.rs`

## Not Changed (frozen history)
- `docs/SPEC-KIT-*` directories (historical specs)

## Test plan
- [x] `rg "/speckit\.new <description>"` - only matches in frozen `docs/SPEC-KIT-*` paths
- [x] `python3 scripts/doc_lint.py` passes
- [x] `bash .githooks/pre-commit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)