### PR TITLE
fix(docs): make doc_lint warnings fatal

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -36,9 +36,11 @@ if [ -n "$DOC_CHANGES" ]; then
         echo ""
         echo "Documentation changes detected, running doc lint..."
         echo "(using canonical: codex-rs/scripts/doc_lint.py)"
-        if ! python3 scripts/doc_lint.py --warn-only; then
+        if ! python3 scripts/doc_lint.py; then
             echo ""
-            echo "⚠️  Doc lint warnings (non-blocking)"
+            echo "❌ Doc lint failed"
+            echo "Fix violations before committing, or skip with: git commit --no-verify"
+            exit 1
         fi
     fi
 fi

--- a/codex-rs/scripts/doc_lint.py
+++ b/codex-rs/scripts/doc_lint.py
@@ -9,7 +9,7 @@ Usage:
 
 Exit codes:
     0 - All checks passed
-    1 - Validation errors found
+    1 - Validation errors or warnings found
     2 - Script error
 
 Checks performed:
@@ -134,7 +134,7 @@ class LintResult:
 
     @property
     def passed(self) -> bool:
-        return len(self.errors) == 0
+        return len(self.errors) == 0 and len(self.warnings) == 0
 
     def __str__(self):
         lines = []
@@ -603,7 +603,7 @@ def main():
     parser.add_argument(
         "--warn-only",
         action="store_true",
-        help="Exit 0 even with errors (treat errors as warnings)"
+        help="Exit 0 even with errors or warnings (treat violations as warnings)"
     )
 
     args = parser.parse_args()

--- a/scripts/README_doc_lint.md
+++ b/scripts/README_doc_lint.md
@@ -28,13 +28,13 @@ cd codex-rs && python3 scripts/doc_lint.py
 ## What it checks (V6 Docs Contract)
 
 - `SPEC.md` has the **Doc Precedence Order** and **Invariants** sections
-- Required files exist (`docs/PROGRAM_2026Q1_ACTIVE.md`, `docs/DECISION_REGISTER.md`)
-- `docs/MODEL-POLICY.md` and `model_policy.toml` exist (model policy enforcement)
+- Required files exist (`DEV_BRIEF.md`, `docs/PROGRAM.md`, `docs/DECISIONS.md`, `docs/POLICY.md`, `docs/SPEC-KIT.md`, `model_policy.toml`, etc.)
 - `model_policy.toml` has required sections (meta, system_of_record, routing, etc.)
-- Active specs 971–980 have Decision IDs sections
+- Active specs listed in `docs/PROGRAM.md` have Decision IDs sections/references
 - Merge terminology uses `curated|full` (not `squash|ff/rebase`)
 - **Replay Truth Table** exists somewhere in docs
 - Key invariants are documented (Stage0 no Memvid dep, URI immutability, etc.)
+- Warnings are treated as failures (exit code 1)
 
 ## Why this exists
 


### PR DESCRIPTION
Enforces strict docs contract:
- doc_lint now fails on warnings (exit 1)
- pre-commit blocks commits when doc_lint reports warnings/errors
- README updated to reflect current contract

Local checks:
- python3 scripts/doc_lint.py
- bash .githooks/pre-commit