### PR TITLE
feat(workflow): require per-branch session briefs

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -16,6 +16,19 @@ if [[ ! -s "DEV_BRIEF.md" ]]; then
     exit 1
 fi
 
+# === Session brief: docs/briefs/<branch>.md required on feature branches ===
+# One branch = one session. Keep DEV_BRIEF.md stable on main; put session context here.
+BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)
+if [[ -n "$BRANCH_NAME" && "$BRANCH_NAME" != "HEAD" && "$BRANCH_NAME" != "main" ]]; then
+    SAFE_BRANCH_NAME=$(echo "$BRANCH_NAME" | sed -E 's#/+#__#g; s#[^A-Za-z0-9._-]#-#g')
+    BRIEF_PATH="docs/briefs/${SAFE_BRANCH_NAME}.md"
+    if [[ ! -s "$BRIEF_PATH" ]]; then
+        echo "❌ Branch brief is missing or empty: $BRIEF_PATH"
+        echo "Create it before committing on this branch. See: docs/briefs/README.md"
+        exit 1
+    fi
+fi
+
 # === SPEC-KIT-964: Config isolation validation ===
 # Always run, regardless of what files changed
 if [[ -f "scripts/validate-config-isolation.sh" ]]; then

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,9 @@ SPEC.md                      # Task tracking (single source of truth)
 * **DEV\_BRIEF.md**: Tier-1 truth anchor (must exist and be non-empty)
   * Update at session start with current focus/constraints
   * Enforced by pre-commit hook (hard block) and doc\_lint
+* **docs/briefs/<branch>.md**: Per-PR session brief (must exist and be non-empty on feature branches)
+  * `<branch>` = git branch name with `/` replaced by `__`
+  * Enforced by pre-commit hook (hard block)
 
 ## Testing Notes
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,9 @@ SPEC.md                      # Task tracking (single source of truth)
 * **DEV\_BRIEF.md**: Tier-1 truth anchor (must exist and be non-empty)
   * Update at session start with current focus/constraints
   * Enforced by pre-commit hook (hard block) and doc\_lint
+* **docs/briefs/<branch>.md**: Per-PR session brief (must exist and be non-empty on feature branches)
+  * `<branch>` = git branch name with `/` replaced by `__`
+  * Enforced by pre-commit hook (hard block)
 
 ## Testing Notes
 

--- a/DEV_BRIEF.md
+++ b/DEV_BRIEF.md
@@ -6,7 +6,9 @@
 
 ## Current Focus
 
-<!-- What are we working on right now? -->
+Idle
+
+<!-- Branch/PR-specific session context lives in docs/briefs/<branch>.md -->
 
 ## Scope / Constraints
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -71,6 +71,9 @@ SPEC.md                      # Task tracking (single source of truth)
 * **DEV\_BRIEF.md**: Tier-1 truth anchor (must exist and be non-empty)
   * Update at session start with current focus/constraints
   * Enforced by pre-commit hook (hard block) and doc\_lint
+* **docs/briefs/<branch>.md**: Per-PR session brief (must exist and be non-empty on feature branches)
+  * `<branch>` = git branch name with `/` replaced by `__`
+  * Enforced by pre-commit hook (hard block)
 
 ## Testing Notes
 

--- a/codex-rs/scripts/doc_lint.py
+++ b/codex-rs/scripts/doc_lint.py
@@ -43,6 +43,7 @@ REQUIRED_FILES = {
     "docs/DECISIONS.md": "Locked decisions register (D1-D134)",
     "docs/POLICY.md": "Consolidated policy (model, gates, evidence, testing)",
     "docs/SPEC-KIT.md": "Canonical spec-kit reference (commands, architecture)",
+    "docs/briefs/README.md": "Branch session brief instructions (per PR/session)",
     "model_policy.toml": "Machine-authoritative model policy config",
 }
 

--- a/docs/briefs/README.md
+++ b/docs/briefs/README.md
@@ -1,0 +1,38 @@
+# Branch Briefs (per PR/session)
+
+Each feature branch / PR is treated as a "session".
+
+To prevent context drift, every branch must include a **non-empty** branch brief:
+
+```
+docs/briefs/<branch>.md
+```
+
+Where `<branch>` is your git branch name with `/` replaced by `__`.
+
+Example:
+
+* Branch: `fix/doc-lint-warnings`
+* Brief: `docs/briefs/fix__doc-lint-warnings.md`
+
+This is enforced by `.githooks/pre-commit` (hard block). Use `DEV_BRIEF.md` on `main`
+as the stable Tier-1 anchor (typically `Current Focus: Idle`).
+
+## Minimal template
+
+Copy this into your branch brief:
+
+```md
+# Session Brief — <branch>
+
+## Goal
+
+## Scope / Constraints
+
+## Plan
+
+## Open Questions
+
+## Verification
+```
+

--- a/docs/briefs/fix__branch-brief-required.md
+++ b/docs/briefs/fix__branch-brief-required.md
@@ -1,0 +1,29 @@
+# Session Brief — fix/branch-brief-required
+
+## Goal
+
+Enforce a non-empty per-branch session brief at `docs/briefs/<branch>.md` (with `/` → `__`) to reduce context drift, while keeping `DEV_BRIEF.md` stable on `main` (`Current Focus: Idle`).
+
+## Scope / Constraints
+
+* Enforced locally via `.githooks/pre-commit` (hard block)
+* `DEV_BRIEF.md` remains required and non-empty
+* No changes to frozen historical docs under `docs/SPEC-KIT-*`
+
+## Plan
+
+1. Add `docs/briefs/README.md` with naming rules and template
+2. Add pre-commit enforcement for `docs/briefs/<branch>.md` on non-main branches
+3. Update agent instruction docs to document the requirement
+
+## Open Questions
+
+* None
+
+## Verification
+
+```bash
+python3 scripts/doc_lint.py
+bash .githooks/pre-commit
+```
+


### PR DESCRIPTION
Adds hard enforcement for per-PR/session briefs:
- Feature branches must include non-empty docs/briefs/<branch>.md (with `/` -> `__`)
- DEV_BRIEF.md stays required and stable on main (Current Focus: Idle)

Local checks:
- python3 scripts/doc_lint.py
- bash .githooks/pre-commit