### PR TITLE
feat(spec-kit): add branch brief refresh CLI

### DIFF
--- a/docs/briefs/fix__speckit-brief-refresh.md
+++ b/docs/briefs/fix__speckit-brief-refresh.md
@@ -1,0 +1,29 @@
+# Session Brief — fix/speckit-brief-refresh
+
+## Goal
+
+Add native CLI command `code speckit brief refresh` to generate/update this branch brief using codex-product (local-memory) + Ollama synthesis.
+
+## Scope / Constraints
+
+* local-memory access via `lm` CLI only (no MCP)
+* Use local LLM (Ollama) for synthesis
+* Do not touch frozen historical docs under `docs/SPEC-KIT-*`
+
+## Plan
+
+1. Add `code speckit brief refresh`
+2. Query `lm search` in `codex-product` and filter (importance>=8, type tag present, no system:true)
+3. Synthesize constraints with Ollama and write to `docs/briefs/<branch>.md`
+
+## Open Questions
+
+* None
+
+## Verification
+
+```bash
+cargo check -p codex-cli
+python3 scripts/doc_lint.py
+bash .githooks/pre-commit
+```

--- a/docs/spec-kit/COMMANDS.md
+++ b/docs/spec-kit/COMMANDS.md
@@ -76,6 +76,30 @@ code speckit projectnew <type> <name> --answers answers.json [--deep] [--json]
 | `--no-bootstrap-spec` | Skip bootstrap spec creation                                  |
 | `--json`              | Output JSON for scripting                                     |
 
+### `code speckit brief refresh`
+
+Generate or update the current **feature-branch session brief** at:
+
+```
+docs/briefs/<branch>.md
+```
+
+Where `<branch>` is your git branch name with `/` replaced by `__` (same rule as `.githooks/pre-commit`).
+
+```bash
+code speckit brief refresh --query "Stage0" [--domain codex-product] [--limit 10] [--ollama-model qwen2.5:3b] [--dry-run] [--json]
+```
+
+| Option                   | Description                                      |
+| ------------------------ | ------------------------------------------------ |
+| `--query <text>`         | Search query for product knowledge               |
+| `--domain <domain>`      | local-memory domain (default: `codex-product`)   |
+| `--limit <n>`            | Max results from local-memory (default: 10)      |
+| `--max-content-length n` | Max characters per memory item (default: 800)    |
+| `--ollama-model <model>` | Ollama model for synthesis (default: `qwen2.5:3b`) |
+| `--dry-run`              | Print the generated block instead of writing     |
+| `--json`                 | Output JSON for scripting                        |
+
 ### `code speckit projections rebuild`
 
 Regenerate filesystem projections from capsule SoR.


### PR DESCRIPTION
Adds native CLI support for per-branch session briefs:

- New command: `code speckit brief refresh`
- Updates/creates `docs/briefs/<branch>.md` (branch sanitized `/` → `__`)
- Sources product knowledge from local-memory domain `codex-product` via `lm search`
- Uses local Ollama for synthesis with strict per-bullet citations (`lm://...`)
- Documents command in `docs/spec-kit/COMMANDS.md`

Local verification:
- `cd codex-rs && cargo fmt --all -- --check`
- `cd codex-rs && cargo clippy -p codex-cli --all-targets --all-features -- -D warnings`
- `cd codex-rs && cargo check -p codex-cli`
- `python3 scripts/doc_lint.py`
- `bash .githooks/pre-commit`
