### PR TITLE
feat(spec-kit): add brief init/check commands

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -24,7 +24,12 @@ if [[ -n "$BRANCH_NAME" && "$BRANCH_NAME" != "HEAD" && "$BRANCH_NAME" != "main" 
     BRIEF_PATH="docs/briefs/${SAFE_BRANCH_NAME}.md"
     if [[ ! -s "$BRIEF_PATH" ]]; then
         echo "❌ Branch brief is missing or empty: $BRIEF_PATH"
-        echo "Create it before committing on this branch. See: docs/briefs/README.md"
+        echo ""
+        echo "To create the brief, run one of:"
+        echo "  code speckit brief init"
+        echo "  code speckit brief refresh --query \"<feature keywords>\""
+        echo ""
+        echo "See: docs/briefs/README.md"
         exit 1
     fi
 fi

--- a/docs/briefs/README.md
+++ b/docs/briefs/README.md
@@ -36,3 +36,24 @@ Copy this into your branch brief:
 ## Verification
 ```
 
+## Quick Start
+
+Initialize brief for your feature branch:
+
+```bash
+code speckit brief init
+```
+
+Then (optionally) enrich with product knowledge:
+
+```bash
+code speckit brief refresh --query "your feature keywords"
+```
+
+## Validation
+
+Check brief exists before committing (CI use):
+
+```bash
+code speckit brief check
+```

--- a/docs/briefs/fix__speckit-brief-init-check.md
+++ b/docs/briefs/fix__speckit-brief-init-check.md
@@ -1,0 +1,34 @@
+# Session Brief — fix/speckit-brief-init-check
+
+## Goal
+
+Add native CLI commands to initialize and validate per-branch session briefs:
+
+- `code speckit brief init`
+- `code speckit brief check`
+
+## Scope / Constraints
+
+- Brief path: `docs/briefs/<branch>.md` where `/` → `__` and other non `[A-Za-z0-9._-]` → `-` (must match `.githooks/pre-commit`).
+- No MCP for local-memory.
+- Keep `doc_lint` strict (warnings are errors).
+
+## Plan
+
+1. Implement `brief init` (template creation + --force)
+2. Implement `brief check` (exists/non-empty + optional marker requirement)
+3. Update docs and pre-commit UX
+
+## Open Questions
+
+- None
+
+## Verification
+
+```bash
+cd codex-rs && cargo fmt --all -- --check
+cd codex-rs && cargo clippy -p codex-cli --all-targets --all-features -- -D warnings
+cd codex-rs && cargo test -p codex-cli
+python3 scripts/doc_lint.py
+bash .githooks/pre-commit
+```

--- a/docs/spec-kit/COMMANDS.md
+++ b/docs/spec-kit/COMMANDS.md
@@ -90,15 +90,49 @@ Where `<branch>` is your git branch name with `/` replaced by `__` (same rule as
 code speckit brief refresh --query "Stage0" [--domain codex-product] [--limit 10] [--ollama-model qwen2.5:3b] [--dry-run] [--json]
 ```
 
-| Option                   | Description                                      |
-| ------------------------ | ------------------------------------------------ |
-| `--query <text>`         | Search query for product knowledge               |
-| `--domain <domain>`      | local-memory domain (default: `codex-product`)   |
-| `--limit <n>`            | Max results from local-memory (default: 10)      |
-| `--max-content-length n` | Max characters per memory item (default: 800)    |
+| Option                   | Description                                        |
+| ------------------------ | -------------------------------------------------- |
+| `--query <text>`         | Search query for product knowledge                 |
+| `--domain <domain>`      | local-memory domain (default: `codex-product`)     |
+| `--limit <n>`            | Max results from local-memory (default: 10)        |
+| `--max-content-length n` | Max characters per memory item (default: 800)      |
 | `--ollama-model <model>` | Ollama model for synthesis (default: `qwen2.5:3b`) |
-| `--dry-run`              | Print the generated block instead of writing     |
-| `--json`                 | Output JSON for scripting                        |
+| `--dry-run`              | Print the generated block instead of writing       |
+| `--json`                 | Output JSON for scripting                          |
+
+### `code speckit brief init`
+
+Initialize the current feature-branch session brief with a minimal template.
+
+```bash
+code speckit brief init [--force] [--json]
+```
+
+| Option    | Description                            |
+| --------- | -------------------------------------- |
+| `--force` | Overwrite existing brief with template |
+| `--json`  | Output JSON for scripting              |
+
+**Behavior**:
+
+* On `main` or detached HEAD: exits with error (briefs are only for feature branches)
+* If brief exists and non-empty: no-op (exits 0)
+* If brief missing or empty: creates from template
+
+### `code speckit brief check`
+
+Validate the current branch session brief exists and is non-empty.
+
+```bash
+code speckit brief check [--json] [--require-refresh-block]
+```
+
+| Option                    | Description                          |
+| ------------------------- | ------------------------------------ |
+| `--json`                  | Output JSON for scripting            |
+| `--require-refresh-block` | Also require the auto-refresh marker |
+
+**Exit codes**: 0 (valid), 2 (missing/empty), 3 (infrastructure error)
 
 ### `code speckit projections rebuild`
 


### PR DESCRIPTION
Adds native CLI helpers for per-branch session briefs:

- `code speckit brief init` (create minimal template; `--force` overwrites)
- `code speckit brief check` (validate exists/non-empty; optional `--require-refresh-block`)
- Improves `.githooks/pre-commit` UX by suggesting the commands when the brief is missing.
- Documents the commands in `docs/spec-kit/COMMANDS.md` and `docs/briefs/README.md`.

Local verification:
- `cd codex-rs && cargo fmt --all -- --check`
- `cd codex-rs && cargo clippy -p codex-cli --all-targets --all-features -- -D warnings`
- `cd codex-rs && cargo test -p codex-cli`
- `python3 scripts/doc_lint.py`
- `bash .githooks/pre-commit`
