### PR TITLE
feat(spec-kit): require capsule snapshot in branch briefs

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -18,6 +18,7 @@ fi
 
 # === Session brief: docs/briefs/<branch>.md required on feature branches ===
 # One branch = one session. Keep DEV_BRIEF.md stable on main; put session context here.
+# Brief must contain refresh block + capsule snapshot (dual-surface SoR).
 BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)
 if [[ -n "$BRANCH_NAME" && "$BRANCH_NAME" != "HEAD" && "$BRANCH_NAME" != "main" ]]; then
     SAFE_BRANCH_NAME=$(echo "$BRANCH_NAME" | sed -E 's#/+#__#g; s#[^A-Za-z0-9._-]#-#g')
@@ -25,11 +26,37 @@ if [[ -n "$BRANCH_NAME" && "$BRANCH_NAME" != "HEAD" && "$BRANCH_NAME" != "main" 
     if [[ ! -s "$BRIEF_PATH" ]]; then
         echo "❌ Branch brief is missing or empty: $BRIEF_PATH"
         echo ""
-        echo "To create the brief, run one of:"
-        echo "  code speckit brief init"
+        echo "To create the brief with capsule snapshot, run:"
         echo "  code speckit brief refresh --query \"<feature keywords>\""
         echo ""
         echo "See: docs/briefs/README.md"
+        exit 1
+    fi
+
+    # Check for refresh marker block
+    if ! grep -q "<!-- BEGIN: SPECKIT_BRIEF_REFRESH -->" "$BRIEF_PATH"; then
+        echo "❌ Branch brief missing refresh block: $BRIEF_PATH"
+        echo ""
+        echo "To add the refresh block with capsule snapshot, run:"
+        echo "  code speckit brief refresh --query \"<feature keywords>\""
+        exit 1
+    fi
+
+    # Check for capsule snapshot (mv2:// URI)
+    if ! grep -q "mv2://" "$BRIEF_PATH"; then
+        echo "❌ Branch brief missing capsule snapshot: $BRIEF_PATH"
+        echo ""
+        echo "To add the capsule snapshot, run:"
+        echo "  code speckit brief refresh --query \"<feature keywords>\""
+        exit 1
+    fi
+
+    # Check for capsule checkpoint marker
+    if ! grep -q -- "- Capsule checkpoint:" "$BRIEF_PATH"; then
+        echo "❌ Branch brief missing capsule checkpoint: $BRIEF_PATH"
+        echo ""
+        echo "To add the capsule snapshot, run:"
+        echo "  code speckit brief refresh --query \"<feature keywords>\""
         exit 1
     fi
 fi

--- a/docs/briefs/README.md
+++ b/docs/briefs/README.md
@@ -18,6 +18,21 @@ Example:
 This is enforced by `.githooks/pre-commit` (hard block). Use `DEV_BRIEF.md` on `main`
 as the stable Tier-1 anchor (typically `Current Focus: Idle`).
 
+## Required Elements
+
+Branch briefs must contain:
+
+1. **Non-empty content** — At least some text describing the session goal
+2. **Refresh block** — The `<!-- BEGIN: SPECKIT_BRIEF_REFRESH -->` marker block
+3. **Capsule snapshot** — An `mv2://` URI and checkpoint line within the refresh block
+
+These elements ensure briefs are:
+
+* Git-committed (version controlled)
+* Capsule-snapshotted (immutable artifact reference)
+
+The pre-commit hook and `code speckit brief check --require-capsule-snapshot` enforce these.
+
 ## Minimal template
 
 Copy this into your branch brief:
@@ -38,22 +53,32 @@ Copy this into your branch brief:
 
 ## Quick Start
 
-Initialize brief for your feature branch:
-
-```bash
-code speckit brief init
-```
-
-Then (optionally) enrich with product knowledge:
+Create brief with product knowledge and capsule snapshot:
 
 ```bash
 code speckit brief refresh --query "your feature keywords"
 ```
 
-## Validation
+This command:
 
-Check brief exists before committing (CI use):
+1. Searches local-memory for relevant product knowledge
+2. Synthesizes constraints via Ollama
+3. Writes the refresh block with capsule metadata
+4. Snapshots the brief to the workspace capsule
+
+Alternatively, create a minimal brief first, then refresh:
 
 ```bash
-code speckit brief check
+code speckit brief init
+code speckit brief refresh --query "your feature keywords"
 ```
+
+## Validation
+
+Check brief exists with all required elements:
+
+```bash
+code speckit brief check --require-refresh-block --require-capsule-snapshot
+```
+
+The pre-commit hook runs equivalent checks automatically.

--- a/docs/briefs/fix__speckit-brief-capsule-sor.md
+++ b/docs/briefs/fix__speckit-brief-capsule-sor.md
@@ -1,0 +1,23 @@
+# Session Brief — fix/speckit-brief-capsule-sor
+
+## Goal
+
+## Scope / Constraints
+
+## Plan
+
+## Open Questions
+
+## Verification
+
+<!-- BEGIN: SPECKIT_BRIEF_REFRESH -->
+## Product Knowledge (auto)
+
+- Query: `xqzv-brief-capsule`
+- Domain: `codex-product`
+- Capsule URI: `mv2://default/WORKFLOW/brief-20260204T044209Z/artifact/briefs/fix__speckit-brief-capsule-sor/20260204T044209Z.md`
+- Capsule checkpoint: `brief-fix__speckit-brief-capsule-sor-20260204T044209Z`
+
+No high-signal product knowledge matched. Try a more specific `--query` and/or raise `--limit`.
+
+<!-- END: SPECKIT_BRIEF_REFRESH -->

--- a/docs/spec-kit/COMMANDS.md
+++ b/docs/spec-kit/COMMANDS.md
@@ -100,6 +100,20 @@ code speckit brief refresh --query "Stage0" [--domain codex-product] [--limit 10
 | `--dry-run`              | Print the generated block instead of writing       |
 | `--json`                 | Output JSON for scripting                          |
 
+**Capsule Snapshot**
+
+On successful refresh, the brief is snapshotted to the workspace capsule with metadata:
+
+* URI format: `mv2://default/WORKFLOW/brief-<UTC>/artifact/briefs/<branch>/<UTC>.md`
+* Checkpoint label: `brief-<branch>-<UTC>`
+
+The refresh block will include:
+
+* `Capsule URI`: stable artifact reference
+* `Capsule checkpoint`: checkpoint identifier
+
+This creates a dual-surface SoR: the brief is both git-committed and capsule-snapshotted.
+
 ### `code speckit brief init`
 
 Initialize the current feature-branch session brief with a minimal template.
@@ -124,15 +138,20 @@ code speckit brief init [--force] [--json]
 Validate the current branch session brief exists and is non-empty.
 
 ```bash
-code speckit brief check [--json] [--require-refresh-block]
+code speckit brief check [--json] [--require-refresh-block] [--require-capsule-snapshot]
 ```
 
-| Option                    | Description                          |
-| ------------------------- | ------------------------------------ |
-| `--json`                  | Output JSON for scripting            |
-| `--require-refresh-block` | Also require the auto-refresh marker |
+| Option                       | Description                                               |
+| ---------------------------- | --------------------------------------------------------- |
+| `--json`                     | Output JSON for scripting                                 |
+| `--require-refresh-block`    | Require the auto-refresh marker block exists              |
+| `--require-capsule-snapshot` | Require refresh block contains capsule URI and checkpoint |
 
-**Exit codes**: 0 (valid), 2 (missing/empty), 3 (infrastructure error)
+**Exit codes**:
+
+* 0: Valid (all requirements met)
+* 2: Missing, empty, or validation failure (refresh block/capsule snapshot missing)
+* 3: Infrastructure error (filesystem, git)
 
 ### `code speckit projections rebuild`
 


### PR DESCRIPTION
Enforces dual-surface SoR for per-branch session briefs (git + capsule).

Key behavior:
- code speckit brief refresh now snapshots the refreshed brief into the workspace capsule and fails with exit 3 if capsule open/put/commit fails.
- Pre-commit hard-blocks feature-branch commits unless the branch brief contains:
  - refresh marker block
  - an mv2:// capsule URI
  - a Capsule checkpoint marker line
- code speckit brief check adds --require-capsule-snapshot.

Notes:
- brief refresh --dry-run no longer emits real mv2:// markers (prevents copy/paste bypass).

Local verification:
- cd codex-rs && cargo fmt --all -- --check
- cd codex-rs && cargo clippy -p codex-cli --all-targets --all-features -- -D warnings
- cd codex-rs && cargo test -p codex-cli
- python3 scripts/doc_lint.py
- bash .githooks/pre-commit
