### PR TITLE
docs: document Stage0/Memvid boundary + fix doc_lint warnings

### DIFF
--- a/DEV_BRIEF.md
+++ b/DEV_BRIEF.md
@@ -8,7 +8,11 @@
 
 Idle
 
-<!-- Branch/PR-specific session context lives in docs/briefs/<branch>.md -->
+## Session Workflow
+
+* `main` branch stays stable; `Current Focus: Idle` between sessions
+* Per-PR context goes in `docs/briefs/<branch>.md` (branch name with `/` replaced by `__`)
+* Branch briefs must be refreshed/snapshotted before commit (enforced by pre-commit)
 
 ## Scope / Constraints
 
@@ -21,7 +25,10 @@ Idle
 
 ## Verification
 
+All must pass (local-only is sufficient):
+
 ```bash
-python3 scripts/doc_lint.py      # Must pass
-bash .githooks/pre-commit        # Must pass
+python3 scripts/doc_lint.py                                            # warnings are errors
+cargo clippy --workspace --all-targets --all-features -- -D warnings   # from codex-rs/
+bash .githooks/pre-commit                                              # full validation
 ```

--- a/codex-rs/scripts/doc_lint.py
+++ b/codex-rs/scripts/doc_lint.py
@@ -503,8 +503,13 @@ def check_invariants_documented(result: LintResult, verbose: bool = False):
         r"replay.*determinism|offline.*replay",
     ]
 
-    # Search in SPEC.md, HANDOFF.md, and docs/
-    search_files = [REPO_ROOT / "SPEC.md", REPO_ROOT / "HANDOFF.md"]
+    # Search in SPEC.md, HANDOFF.md, codex-rs/SPEC.md, codex-rs/HANDOFF.md, and docs/
+    search_files = [
+        REPO_ROOT / "SPEC.md",
+        REPO_ROOT / "HANDOFF.md",
+        REPO_ROOT / "codex-rs" / "SPEC.md",
+        REPO_ROOT / "codex-rs" / "HANDOFF.md",
+    ]
     search_files += list(REPO_ROOT.glob("docs/**/*.md"))
 
     all_content = ""
@@ -520,7 +525,7 @@ def check_invariants_documented(result: LintResult, verbose: bool = False):
         if not re.search(inv_pattern, all_content, re.IGNORECASE):
             missing.append(inv_pattern)
 
-    if missing and verbose:
+    if missing:
         for m in missing:
             result.add_warning(
                 "docs/",

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -73,12 +73,13 @@ User input (TUI)
 
 ## 2. Key Boundaries
 
-| Boundary           | Location                                | Description                                                                                |
-| ------------------ | --------------------------------------- | ------------------------------------------------------------------------------------------ |
-| UX + Orchestration | `codex-rs/tui/src/chatwidget/spec_kit/` | User-facing commands and pipeline coordination                                             |
-| Shared Library     | `codex-rs/spec-kit/`                    | Config, retry logic, shared types                                                          |
-| Templates          | `./templates/` (project-local)          | Prompt templates with embedded fallbacks                                                   |
-| Evidence Store     | `docs/SPEC-OPS-004-.../evidence/`       | Telemetry, artifacts, synthesis data. **Note**: Capsule is the SOR; filesystem is derived. |
+| Boundary           | Location                                | Description                                                                                                                                                              |
+| ------------------ | --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| UX + Orchestration | `codex-rs/tui/src/chatwidget/spec_kit/` | User-facing commands and pipeline coordination                                                                                                                           |
+| Shared Library     | `codex-rs/spec-kit/`                    | Config, retry logic, shared types                                                                                                                                        |
+| Templates          | `./templates/` (project-local)          | Prompt templates with embedded fallbacks                                                                                                                                 |
+| Evidence Store     | `docs/SPEC-OPS-004-.../evidence/`       | Telemetry, artifacts, synthesis data. **Note**: Capsule is the SOR; filesystem is derived.                                                                               |
+| Stage0 Adapters    | `codex-rs/tui/src/stage0_adapters.rs`   | Memory/Tier2 abstraction layer; Stage0 core has no Memvid dependency (see [STAGE0-REFERENCE.md](STAGE0-REFERENCE.md#5-stage0-has-no-memvid-dependency-adapter-boundary)) |
 
 ***
 

--- a/docs/briefs/fix__doc-lint-invariant-docs.md
+++ b/docs/briefs/fix__doc-lint-invariant-docs.md
@@ -1,0 +1,48 @@
+# Session Brief — fix/doc-lint-invariant-docs
+
+## Goal
+
+Document the Stage0↔Memvid boundary with rationale in canonical docs, fix doc_lint.py to have consistent warning behavior (no "only warns in --verbose"), and update DEV_BRIEF.md to reflect verification + session workflow expectations.
+
+## Scope / Constraints
+
+- Stage0 core has no Memvid dependency (locked invariant)
+- Capsule (mv2://…) is SoR; filesystem is projection
+- local-memory usage is CLI/REST only (no MCP)
+- Doc lint warnings must be fatal regardless of --verbose flag
+
+## Plan
+
+1. Update DEV_BRIEF.md with session workflow note + expanded verification
+2. Add Stage0↔Memvid boundary section to docs/STAGE0-REFERENCE.md
+3. Add cross-reference row in docs/ARCHITECTURE.md Key Boundaries table
+4. Fix doc_lint.py: remove verbose guard, expand search files to include codex-rs/
+5. Run verification (doc_lint default + verbose, pre-commit)
+6. Open PR
+
+## Open Questions
+
+None - requirements are specific.
+
+## Verification
+
+```bash
+python3 scripts/doc_lint.py                                       # must exit 0
+python3 scripts/doc_lint.py --verbose                             # must exit 0 (same behavior)
+cargo clippy --workspace --all-targets --all-features -- -D warnings  # from codex-rs/
+bash .githooks/pre-commit                                         # must pass
+```
+
+<!-- BEGIN: SPECKIT_BRIEF_REFRESH -->
+## Product Knowledge (auto)
+- Query: `doc_lint invariants Stage0 memvid boundary`
+- Domain: `codex-product`
+- Capsule URI: `mv2://default/WORKFLOW/brief-20260204T143731Z/artifact/briefs/fix__doc-lint-invariant-docs/20260204T143731Z.md`
+- Capsule checkpoint: `brief-fix__doc-lint-invariant-docs-20260204T143731Z`
+
+Relevant context from local-memory and session start hook:
+- BUG-FIX GAP: SPEC-KIT-981/982 commit 175c68f33 adds SpecKitStageAgents config + prompt_vars builder
+- Spec-Kit prompt system drift (Jan 2026): runtime uses TWO prompt sources
+- PATTERN: Treat codex-rs/SPEC.md as canonical completion tracker
+
+<!-- END: SPECKIT_BRIEF_REFRESH -->


### PR DESCRIPTION
## Summary
- Document Stage0↔Memvid adapter boundary with rationale in STAGE0-REFERENCE.md
- Fix doc_lint.py so warnings are recorded regardless of --verbose flag
- Expand doc_lint scan sources to include codex-rs/SPEC.md and codex-rs/HANDOFF.md
- Update DEV_BRIEF.md with verification commands and session workflow expectations

## Changes

### STAGE0-REFERENCE.md
Added new section "Stage0 Has No Memvid Dependency (Adapter Boundary)" with:
- 5 rationale bullets explaining WHY the boundary exists (layering/cycles, testability, SoR separation, determinism, backend flexibility)
- Mechanism description (LocalMemoryClient trait → adapters)
- Key adapter implementations table
- Invariants reference to codex-rs/SPEC.md

### ARCHITECTURE.md
Added cross-reference row in "Key Boundaries" table linking to the new STAGE0-REFERENCE.md section.

### doc_lint.py
- **Bug fix**: Removed `and verbose` guard from `check_invariants_documented()` so warnings are always recorded (line 523)
- **Enhancement**: Expanded search files to include `codex-rs/SPEC.md` and `codex-rs/HANDOFF.md`

### DEV_BRIEF.md
- Added "Session Workflow" section explaining main stays stable, branch briefs hold PR context
- Expanded "Verification" section to include `cargo clippy` check

## doc_lint Output

```
$ python3 scripts/doc_lint.py
✅ All checks passed!
Exit code: 0

$ python3 scripts/doc_lint.py --verbose
[verbose output with all checks shown]
✅ All checks passed!
Exit code: 0
```

## Test plan
- [x] `python3 scripts/doc_lint.py` exits 0
- [x] `python3 scripts/doc_lint.py --verbose` exits 0 (same behavior)
- [x] `bash .githooks/pre-commit` passes

## Files Changed
- DEV_BRIEF.md (verification + session workflow)
- docs/STAGE0-REFERENCE.md (new boundary section)
- docs/ARCHITECTURE.md (cross-reference row)
- codex-rs/scripts/doc_lint.py (warning consistency fix)
- docs/briefs/fix__doc-lint-invariant-docs.md (branch brief)

🤖 Generated with [Claude Code](https://claude.com/claude-code)