### PR TITLE
feat(workflow): staged-only rustfmt gate for pre-commit

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -90,6 +90,23 @@ if [ -n "$RUST_CHANGES" ]; then
     fi
 fi
 
+# === Rustfmt gate: run only when Rust/Cargo files are staged ===
+# Uses same detection as clippy gate above
+if [ -n "$RUST_CHANGES" ]; then
+    echo ""
+    echo "Rust changes detected, running rustfmt check..."
+    FMT_CMD="cargo fmt --all -- --check"
+    if ! (cd codex-rs && $FMT_CMD); then
+        echo ""
+        echo "❌ Rustfmt found formatting issues"
+        echo "Run the following to fix:"
+        echo "  cd codex-rs && cargo fmt --all"
+        echo ""
+        echo "Fix formatting before committing, or skip with: git commit --no-verify"
+        exit 1
+    fi
+fi
+
 # === V6 Doc Contract: Documentation lint (SPEC-KIT-972) ===
 # Run doc lint if any .md files or docs/ changed
 # NOTE: scripts/doc_lint.py forwards to canonical codex-rs/scripts/doc_lint.py

--- a/docs/briefs/fix__precommit-rustfmt-gate.md
+++ b/docs/briefs/fix__precommit-rustfmt-gate.md
@@ -1,0 +1,46 @@
+# Session Brief — fix/precommit-rustfmt-gate
+
+## Goal
+
+Add a staged-only rustfmt gate to pre-commit hook, mirroring the existing clippy gate pattern.
+
+## Scope / Constraints
+
+- Rustfmt gate runs only when staged Rust/Cargo files exist (same trigger as clippy)
+- Run from codex-rs/: `cargo fmt --all -- --check`
+- Fail with actionable error showing fix command
+- Doc-only commits remain fast
+
+## Plan
+
+1. Add rustfmt gate after clippy gate in `.githooks/pre-commit`
+2. Reuse `$RUST_CHANGES` variable (already computed for clippy)
+3. Verify doc-only and Rust change scenarios
+
+## Open Questions
+
+None
+
+## Verification
+
+```bash
+# Doc-only should skip
+echo "test" >> README.md && git add README.md
+bash .githooks/pre-commit  # Should skip fmt check
+git reset HEAD README.md && git checkout README.md
+
+# Rust changes should trigger
+bash .githooks/pre-commit  # Should run fmt on staged .rs files
+```
+
+<!-- BEGIN: SPECKIT_BRIEF_REFRESH -->
+## Product Knowledge (auto)
+
+- Query: `pre-commit staged-only rustfmt gate`
+- Domain: `codex-product`
+- Capsule URI: `mv2://default/WORKFLOW/brief-20260204T225800Z/artifact/briefs/fix__precommit-rustfmt-gate/20260204T225800Z.md`
+- Capsule checkpoint: `brief-fix__precommit-rustfmt-gate-20260204T225800Z`
+
+Pre-commit hook rustfmt gate implementation session. Gate pattern: detect staged .rs/Cargo files -> run cargo fmt --check -> block on failure with actionable fix command.
+
+<!-- END: SPECKIT_BRIEF_REFRESH -->


### PR DESCRIPTION
## Summary

- Add `cargo fmt --all -- --check` gate to pre-commit hook
- Trigger condition: staged Rust/Cargo files under `codex-rs/` (same as clippy gate)
- Provides actionable error message showing exact fix command
- Doc-only commits remain fast (skip fmt check entirely)

## Test plan

- [x] Doc-only staged change → hook skips fmt check
- [x] Formatted Rust change → hook runs fmt check, passes
- [x] Unformatted Rust change → hook blocks with actionable message

🤖 Generated with [Claude Code](https://claude.com/claude-code)