### PR TITLE
fix(workflow): make Preview Build manual-only

### DIFF
--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -1,8 +1,6 @@
 name: Preview Build
 
 on:
-  pull_request:
-    types: [opened, reopened, ready_for_review, synchronize]
   workflow_dispatch: {}
 
 concurrency:

--- a/docs/briefs/fix__preview-build-manual.md
+++ b/docs/briefs/fix__preview-build-manual.md
@@ -1,0 +1,23 @@
+# Session Brief — fix/preview-build-manual
+
+## Goal
+
+## Scope / Constraints
+
+## Plan
+
+## Open Questions
+
+## Verification
+
+<!-- BEGIN: SPECKIT_BRIEF_REFRESH -->
+## Product Knowledge (auto)
+
+- Query: `Preview Build manual-only; not merge required`
+- Domain: `codex-product`
+- Capsule URI: `mv2://default/WORKFLOW/brief-20260205T015913Z/artifact/briefs/fix__preview-build-manual/20260205T015913Z.md`
+- Capsule checkpoint: `brief-fix__preview-build-manual-20260205T015913Z`
+
+No high-signal product knowledge matched. Try a more specific `--query` and/or raise `--limit`.
+
+<!-- END: SPECKIT_BRIEF_REFRESH -->


### PR DESCRIPTION
Summary:
- Preview Build workflow no longer runs automatically on every PR.
- It is now manual-only via workflow_dispatch.

Notes:
- Merge requirement for Preview Build was removed from main branch protection separately (settings change).