### PR TITLE
fix(workflow): run Spec-Kit CI daily

### DIFF
--- a/.github/workflows/spec-kit-ci.yml
+++ b/.github/workflows/spec-kit-ci.yml
@@ -1,10 +1,10 @@
 name: Spec-Kit CI
 
 on:
-  pull_request:
-    branches: [ main ]
-  push:
-    branches: [ main ]
+  schedule:
+    # Daily (UTC). Heavy Spec-Kit contract/pipeline checks don't need to run on every PR.
+    - cron: '0 4 * * *' # 04:00 UTC daily
+  workflow_dispatch: {}
 
 permissions:
   contents: read

--- a/docs/briefs/fix__spec-kit-ci-daily.md
+++ b/docs/briefs/fix__spec-kit-ci-daily.md
@@ -1,0 +1,23 @@
+# Session Brief — fix/spec-kit-ci-daily
+
+## Goal
+
+## Scope / Constraints
+
+## Plan
+
+## Open Questions
+
+## Verification
+
+<!-- BEGIN: SPECKIT_BRIEF_REFRESH -->
+## Product Knowledge (auto)
+
+- Query: `Move Spec-Kit CI off PRs; run daily scheduled + manual only`
+- Domain: `codex-product`
+- Capsule URI: `mv2://default/WORKFLOW/brief-20260205T023240Z/artifact/briefs/fix__spec-kit-ci-daily/20260205T023240Z.md`
+- Capsule checkpoint: `brief-fix__spec-kit-ci-daily-20260205T023240Z`
+
+No high-signal product knowledge matched. Try a more specific `--query` and/or raise `--limit`.
+
+<!-- END: SPECKIT_BRIEF_REFRESH -->


### PR DESCRIPTION
Summary:
- Stops running Spec-Kit CI (contract + pipeline checks) on every PR.
- Runs it daily on a schedule + still allows manual workflow_dispatch.

Motivation:
- PR CI was slow due to the heavy Spec-Kit contract/pipeline job; this moves that cost to a daily check.