### PR TITLE
docs(tracker): re-anchor SPEC.md roadmap

### DIFF
--- a/codex-rs/SPEC.md
+++ b/codex-rs/SPEC.md
@@ -1,7 +1,7 @@
 # SPEC.md - Codex-RS / Spec-Kit Task Tracking
 
 **Version:** V6 Docs Contract
-**Last Updated:** 2026-01-31
+**Last Updated:** 2026-02-05
 
 ***
 
@@ -108,7 +108,10 @@ These invariants MUST NOT be violated:
 
 | Spec | Description |
 | ---- | ----------- |
-| -    | -           |
+| SPEC-DOGFOOD-002 | Canonical gold run: prove `/speckit.auto` happy path + complete evidence chain on Linux; add a scheduled CI run once stable. |
+| SPEC-PK-001 | Product knowledge (codex-product) dogfood + measurement: validate determinism (snapshot/evidence pack) and quantify Tier2 reduction/curation quality. |
+| SPEC-PM-001 | Project management deep dive: define/ship feature + task tracking, maieutic PRD sessions, and status surfaces (CLI/TUI/headless) using `SPEC.md` as the SoT. |
+| DOC-DRIFT-001 | Docs drift control: deprecate/update legacy PRDs/roadmaps that conflict with current product vision; ensure doc maps point to canonical trackers. |
 
 ### Completed (Recent)
 

--- a/codex-rs/docs/GOLD_RUN_PLAYBOOK.md
+++ b/codex-rs/docs/GOLD_RUN_PLAYBOOK.md
@@ -1,8 +1,10 @@
 # Gold Run Playbook
 
+> **Status**: Needs refresh. Use `codex-rs/SPEC.md` as the canonical tracker for the current gold-run SPEC and acceptance criteria.
+
 **Purpose**: Reproducible steps to validate the `/speckit.auto` pipeline produces a complete evidence chain.
 
-**Target SPEC**: SPEC-KIT-900
+**Target SPEC**: SPEC-DOGFOOD-002
 
 ---
 
@@ -51,14 +53,14 @@ git stash push -m "pre-gold-run"
 ./target/release/codex-tui
 
 # Run gold run SPEC
-/speckit.auto SPEC-KIT-900
+/speckit.auto SPEC-DOGFOOD-002
 ```
 
 ### Option B: Automated Mode
 
 ```bash
 # Single command (useful for CI)
-./target/release/codex-tui --initial-command "/speckit.auto SPEC-KIT-900"
+./target/release/codex-tui --initial-command "/speckit.auto SPEC-DOGFOOD-002"
 ```
 
 ---
@@ -67,7 +69,7 @@ git stash push -m "pre-gold-run"
 
 ```
 Stage 0: Context Injection
-├── Load spec.md from docs/SPEC-KIT-900-gold-run/
+├── Load spec.md from docs/SPEC-DOGFOOD-002/
 ├── Generate TASK_BRIEF.md (if tier2 enabled)
 └── Inject context into agent prompts
 
@@ -116,13 +118,13 @@ Stage 6: Unlock
 After pipeline completes, run:
 
 ```bash
-/speckit.verify SPEC-KIT-900
+/speckit.verify SPEC-DOGFOOD-002
 ```
 
 ### Expected Output
 
 ```
-SPEC-KIT-900 Verification Report
+SPEC-DOGFOOD-002 Verification Report
 ================================
 
 Stage Artifacts:
@@ -134,7 +136,7 @@ Stage Artifacts:
   [x] unlock.md exists (N bytes)
 
 Evidence Chain:
-  [x] evidence/consensus/SPEC-KIT-900/ directory exists
+  [x] evidence/consensus/SPEC-DOGFOOD-002/ directory exists
   [x] 12 verdict files present
   [x] Cost summary written
 
@@ -155,7 +157,7 @@ Result: PASS
 **Symptom**: No progress for >5 minutes
 
 **Actions**:
-1. Check `/speckit.status SPEC-KIT-900`
+1. Check `/speckit.status SPEC-DOGFOOD-002`
 2. Look for "waiting on model output" in status
 3. Check API rate limits if using external providers
 
@@ -165,7 +167,7 @@ Result: PASS
 
 **Actions**:
 1. Check evidence files for specific failure reason
-2. Review `evidence/consensus/SPEC-KIT-900/<stage>_verdict.json`
+2. Review `evidence/consensus/SPEC-DOGFOOD-002/<stage>_verdict.json`
 3. If sidecar critic enabled, check for advisory signals
 
 ### Missing Evidence Files
@@ -214,21 +216,21 @@ jobs:
       - name: Run Gold SPEC
         run: |
           timeout 30m ./target/release/codex-tui \
-            --initial-command "/speckit.auto SPEC-KIT-900"
+            --initial-command "/speckit.auto SPEC-DOGFOOD-002"
         working-directory: codex-rs
         env:
           SPEC_KIT_AUTO_COMMIT: true
 
       - name: Verify Evidence
         run: ./target/release/codex-tui \
-          --initial-command "/speckit.verify SPEC-KIT-900"
+          --initial-command "/speckit.verify SPEC-DOGFOOD-002"
         working-directory: codex-rs
 
       - name: Upload Evidence
         uses: actions/upload-artifact@v4
         with:
           name: gold-run-evidence
-          path: codex-rs/evidence/consensus/SPEC-KIT-900/
+          path: codex-rs/evidence/consensus/SPEC-DOGFOOD-002/
 ```
 
 ---
@@ -237,8 +239,8 @@ jobs:
 
 A successful gold run produces:
 
-1. **6 stage artifacts** in `docs/SPEC-KIT-900-gold-run/`
-2. **12 evidence files** in `evidence/consensus/SPEC-KIT-900/`
+1. **6 stage artifacts** in `docs/SPEC-DOGFOOD-002/`
+2. **12 evidence files** in `evidence/consensus/SPEC-DOGFOOD-002/`
 3. **Cost summary** with timing data
 4. **Zero manual intervention** after initiation
 5. **Clean git history** (if auto-commit enabled)

--- a/codex-rs/docs/NEXT_FOCUS_ROADMAP.md
+++ b/codex-rs/docs/NEXT_FOCUS_ROADMAP.md
@@ -1,5 +1,9 @@
 # Planner / Spec-Kit — Next Focus Roadmap (Architect Review)
 
+> **Status**: Deprecated as a canonical roadmap. Use `SPEC.md` / `codex-rs/SPEC.md` as the single source of truth for active/planned work.
+>
+> This document is retained for historical context and may describe superseded priorities or terminology.
+
 **Date:** 2025-12-19 (Updated: post-automation-review)
 **Context:** Post PR7-PR9 (gate/review vocabulary migration + CI hardening complete)
 

--- a/codex-rs/docs/SPEC-KIT-900-gold-run/spec.md
+++ b/codex-rs/docs/SPEC-KIT-900-gold-run/spec.md
@@ -1,6 +1,10 @@
 # SPEC-KIT-900: Gold Run Pipeline Validation
 
-## Status: IN_PROGRESS
+> **Status**: Deprecated.
+>
+> `SPEC-KIT-900` is tracked as completed in `codex-rs/SPEC.md` (headless CLI parity work). The gold-run validation effort is tracked separately in `codex-rs/SPEC.md` (see planned `SPEC-DOGFOOD-002`).
+
+## Status: DEPRECATED
 
 ## Overview
 

--- a/docs/SPEC-DOGFOOD-002/spec.md
+++ b/docs/SPEC-DOGFOOD-002/spec.md
@@ -1,0 +1,50 @@
+# SPEC-DOGFOOD-002: Gold Run (Pipeline + Evidence)
+
+## Status: PLANNED
+
+## Overview
+
+Canonical dogfood SPEC to validate the `/speckit.auto` pipeline completes end-to-end and produces a complete evidence chain on the local platform (Linux).
+
+This SPEC exists to prove the happy path works in practice (not just in unit/integration tests):
+
+1. All stages complete: Plan → Tasks → Implement → Validate → Audit → Unlock
+2. Gates execute at each transition
+3. Artifacts/evidence are persisted to the system-of-record (Memvid capsule) with filesystem projections as best-effort
+4. `/speckit.verify` reports a coherent pass/fail with actionable diagnostics
+
+## Scope
+
+**In scope**
+- Run `/speckit.auto SPEC-DOGFOOD-002` on Linux
+- Verify expected stage artifacts exist under `docs/SPEC-DOGFOOD-002/`
+- Verify evidence exists in the capsule and is sufficient for audit/replay (per `docs/PROGRAM.md` and `docs/DECISIONS.md`)
+- Capture timing/cost summary if available
+
+**Out of scope**
+- Cross-platform compatibility (macOS/Windows)
+- New orchestration patterns (committees/voting/etc.)
+
+## Expected Artifacts
+
+```
+docs/SPEC-DOGFOOD-002/
+├── spec.md
+├── plan.md
+├── tasks.md
+├── implement.md
+├── validate.md
+├── audit.md
+└── unlock.md
+```
+
+## Definition of Done
+
+- `/speckit.auto SPEC-DOGFOOD-002` completes without manual intervention beyond initiation
+- `/speckit.verify SPEC-DOGFOOD-002` reports PASS (or a single well-scoped blocking failure with clear remediation)
+- Evidence/artifacts are replay/audit friendly per program DoD (`docs/PROGRAM.md`)
+
+## References
+
+- Canonical tracker: `codex-rs/SPEC.md` (Planned: SPEC-DOGFOOD-002)
+- Playbook (needs refresh): `codex-rs/docs/GOLD_RUN_PLAYBOOK.md`

--- a/docs/briefs/fix__spec-tracker-drift.md
+++ b/docs/briefs/fix__spec-tracker-drift.md
@@ -1,0 +1,23 @@
+# Session Brief — fix/spec-tracker-drift
+
+## Goal
+
+## Scope / Constraints
+
+## Plan
+
+## Open Questions
+
+## Verification
+
+<!-- BEGIN: SPECKIT_BRIEF_REFRESH -->
+## Product Knowledge (auto)
+
+- Query: `Rein in roadmap drift: make SPEC.md canonical again; add stubs for gold run, product knowledge, and project management features`
+- Domain: `codex-product`
+- Capsule URI: `mv2://default/WORKFLOW/brief-20260205T161630Z/artifact/briefs/fix__spec-tracker-drift/20260205T161630Z.md`
+- Capsule checkpoint: `brief-fix__spec-tracker-drift-20260205T161630Z`
+
+No high-signal product knowledge matched. Try a more specific `--query` and/or raise `--limit`.
+
+<!-- END: SPECKIT_BRIEF_REFRESH -->


### PR DESCRIPTION
Summary:
- Re-populates `codex-rs/SPEC.md` Planned items (gold run, product knowledge, project management deep dive, docs drift).
- Deprecates outdated internal roadmap docs that conflicted with the canonical tracker.
- Adds stub spec dir `docs/SPEC-DOGFOOD-002/` for the new gold-run target referenced by the playbook.

Notes:
- This is doc-only; no code behavior changes.