### PR TITLE
docs(tracker): add deprecations register

### DIFF
--- a/codex-rs/SPEC.md
+++ b/codex-rs/SPEC.md
@@ -110,8 +110,8 @@ These invariants MUST NOT be violated:
 | ---- | ----------- |
 | SPEC-DOGFOOD-002 | Canonical gold run: prove `/speckit.auto` happy path + complete evidence chain on Linux; add a scheduled CI run once stable. |
 | SPEC-PK-001 | Product knowledge (codex-product) dogfood + measurement: validate determinism (snapshot/evidence pack) and quantify Tier2 reduction/curation quality. |
-| SPEC-PM-001 | Project management deep dive: define/ship feature + task tracking, maieutic PRD sessions, and status surfaces (CLI/TUI/headless) using `SPEC.md` as the SoT. |
-| DOC-DRIFT-001 | Docs drift control: deprecate/update legacy PRDs/roadmaps that conflict with current product vision; ensure doc maps point to canonical trackers. |
+| SPEC-PM-001 | Project management deep dive: capsule-backed feature + task tracking (SoR) with filesystem projections (including `SPEC.md`), maieutic PRD sessions, and status surfaces (CLI/TUI/headless). |
+| DOC-DRIFT-001 | Docs drift control: maintain `docs/DEPRECATIONS.md`, deprecate/update legacy PRDs/roadmaps that conflict with current product vision, and keep doc maps pointing at canonical trackers. |
 
 ### Completed (Recent)
 

--- a/codex-rs/scripts/doc_lint.py
+++ b/codex-rs/scripts/doc_lint.py
@@ -51,6 +51,7 @@ REQUIRED_FILES = {
 CANONICAL_DOCS_ROOT = {
     "docs/KEY_DOCS.md": "Canonical doc map",
     "docs/INDEX.md": "Documentation index",
+    "docs/DEPRECATIONS.md": "Deprecated/superseded docs register",
     "docs/POLICY.md": "Consolidated policy",
     "docs/OPERATIONS.md": "Consolidated operations",
     "docs/ARCHITECTURE.md": "System architecture",

--- a/docs/DEPRECATIONS.md
+++ b/docs/DEPRECATIONS.md
@@ -1,0 +1,32 @@
+# Deprecations Register
+
+Single canonical list of deprecated/superseded documentation and their replacements.
+
+**Why this exists**
+
+- Reduce roadmap/spec drift by making deprecations explicit and discoverable.
+- Preserve historical context without letting legacy docs override current truth.
+
+**Policy**
+
+- When a doc is no longer canonical, add a **top-of-file banner** in the doc and an entry here.
+- For historical/frozen docs (notably under `docs/SPEC-KIT-*`), prefer adding an entry here and only add minimal banner text when needed.
+
+**Status meanings**
+
+- **Deprecated**: Retained for history; do not treat as current guidance.
+- **Superseded**: Replaced by a newer doc (link provided); old doc should not be updated further.
+- **Needs refresh**: Still useful, but not safe to treat as canonical until updated.
+
+## Register
+
+| Document | Status | Replacement / Canonical Reference | Notes | Deprecated On |
+| --- | --- | --- | --- | --- |
+| `codex-rs/docs/NEXT_FOCUS_ROADMAP.md` | Deprecated | `SPEC.md` → `codex-rs/SPEC.md` | Historical roadmap; conflicts resolved by `codex-rs/SPEC.md` doc precedence order. | 2026-02-05 |
+| `codex-rs/docs/SPEC-KIT-900-gold-run/spec.md` | Superseded | `docs/SPEC-DOGFOOD-002/spec.md` + `codex-rs/SPEC.md` (Planned) | `SPEC-KIT-900` is completed work; gold-run validation is tracked separately as `SPEC-DOGFOOD-002`. | 2026-02-05 |
+| `codex-rs/docs/GOLD_RUN_PLAYBOOK.md` | Needs refresh | `docs/SPEC-DOGFOOD-002/spec.md` + `codex-rs/SPEC.md` (Planned) | Keep as playbook, but acceptance criteria lives in the SPEC and tracker. | 2026-02-05 |
+
+## Planned: Capsule-backed tracking
+
+Long-term, deprecations should be emitted as capsule events and projected into this register. Track design/implementation in `codex-rs/SPEC.md` (Planned: `SPEC-PM-001`).
+

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -4,6 +4,7 @@
 
 * `INDEX.md` (this file)
 * `KEY_DOCS.md`
+* `DEPRECATIONS.md`
 * `VISION.md`
 * `ARCHITECTURE.md`
 * `POLICY.md`

--- a/docs/KEY_DOCS.md
+++ b/docs/KEY_DOCS.md
@@ -5,6 +5,7 @@ This repo has a small set of canonical documents. If you’re unsure what to rea
 | File                                                        | Type               | Purpose                                                            |
 | ----------------------------------------------------------- | ------------------ | ------------------------------------------------------------------ |
 | [`docs/KEY_DOCS.md`](KEY_DOCS.md)                           | Map                | Canonical doc map (this file)                                      |
+| [`docs/DEPRECATIONS.md`](DEPRECATIONS.md)                   | Register           | Deprecated/superseded docs and their replacements                  |
 | [`docs/POLICY.md`](POLICY.md)                               | Policy             | Consolidated policy (model, gates, evidence, testing)              |
 | [`docs/OPERATIONS.md`](OPERATIONS.md)                       | Operations         | Consolidated operations (playbook + config reference)              |
 | [`docs/ARCHITECTURE.md`](ARCHITECTURE.md)                   | Architecture       | System architecture (TUI, async/sync, pipeline, consensus)         |

--- a/docs/briefs/fix__docs-deprecations-register.md
+++ b/docs/briefs/fix__docs-deprecations-register.md
@@ -1,0 +1,23 @@
+# Session Brief — fix/docs-deprecations-register
+
+## Goal
+
+## Scope / Constraints
+
+## Plan
+
+## Open Questions
+
+## Verification
+
+<!-- BEGIN: SPECKIT_BRIEF_REFRESH -->
+## Product Knowledge (auto)
+
+- Query: `Docs deprecations register; capsule-backed tracker`
+- Domain: `codex-product`
+- Capsule URI: `mv2://default/WORKFLOW/brief-20260205T170017Z/artifact/briefs/fix__docs-deprecations-register/20260205T170017Z.md`
+- Capsule checkpoint: `brief-fix__docs-deprecations-register-20260205T170017Z`
+
+No high-signal product knowledge matched. Try a more specific `--query` and/or raise `--limit`.
+
+<!-- END: SPECKIT_BRIEF_REFRESH -->


### PR DESCRIPTION
Summary:
- Adds `docs/DEPRECATIONS.md` as the canonical register for deprecated/superseded docs + replacements.
- Links the register from `docs/KEY_DOCS.md` and `docs/INDEX.md`.
- Updates `codex-rs/SPEC.md` planned items to explicitly call out capsule-backed PM tracking + the deprecations register.
- Extends `codex-rs/scripts/doc_lint.py` canonical-doc allowlist to include `docs/DEPRECATIONS.md`.

Validation:
- `python3 scripts/doc_lint.py`
- `bash .githooks/pre-commit`