### PR TITLE
docs(deprecations): codify PRD archive policy

### DIFF
--- a/docs/DEPRECATIONS.md
+++ b/docs/DEPRECATIONS.md
@@ -10,6 +10,7 @@ Single canonical list of deprecated/superseded documentation and their replaceme
 **Policy**
 
 - When a doc is no longer canonical, add a **top-of-file banner** in the doc and an entry here.
+- Deprecated PRDs are **archived into zip packs under `archive/` and removed from the working tree** (no stubs); this register is the canonical pointer.
 - For historical/frozen docs (notably under `docs/SPEC-KIT-*`), prefer adding an entry here and only add minimal banner text when needed.
 
 **Status meanings**
@@ -29,4 +30,3 @@ Single canonical list of deprecated/superseded documentation and their replaceme
 ## Planned: Capsule-backed tracking
 
 Long-term, deprecations should be emitted as capsule events and projected into this register. Track design/implementation in `codex-rs/SPEC.md` (Planned: `SPEC-PM-001`).
-

--- a/docs/briefs/fix__deprecations-prd-archive-policy.md
+++ b/docs/briefs/fix__deprecations-prd-archive-policy.md
@@ -1,0 +1,23 @@
+# Session Brief — fix/deprecations-prd-archive-policy
+
+## Goal
+
+## Scope / Constraints
+
+## Plan
+
+## Open Questions
+
+## Verification
+
+<!-- BEGIN: SPECKIT_BRIEF_REFRESH -->
+## Product Knowledge (auto)
+
+- Query: `Codify policy: deprecated PRDs are archived to zip packs and removed from tree`
+- Domain: `codex-product`
+- Capsule URI: `mv2://default/WORKFLOW/brief-20260205T202144Z/artifact/briefs/fix__deprecations-prd-archive-policy/20260205T202144Z.md`
+- Capsule checkpoint: `brief-fix__deprecations-prd-archive-policy-20260205T202144Z`
+
+No high-signal product knowledge matched. Try a more specific `--query` and/or raise `--limit`.
+
+<!-- END: SPECKIT_BRIEF_REFRESH -->


### PR DESCRIPTION
Summary:
- Codifies the agreed policy: deprecated PRDs are archived into zip packs under `archive/` and removed from the working tree (no stubs), with `docs/DEPRECATIONS.md` as the canonical pointer.

Validation:
- python3 scripts/doc_lint.py
- python3 scripts/check_doc_links.py
- bash .githooks/pre-commit