### PR TITLE
ci(workflows): linux-only PR checks

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,18 +1,10 @@
 name: Code Coverage
 
 on:
-  push:
-    branches: [ main ]
-    paths:
-      - 'codex-rs/**/*.rs'
-      - 'codex-rs/**/Cargo.toml'
-      - '.github/workflows/coverage.yml'
-  pull_request:
-    branches: [ main ]
-    paths:
-      - 'codex-rs/**/*.rs'
-      - 'codex-rs/**/Cargo.toml'
-      - '.github/workflows/coverage.yml'
+  schedule:
+    # Weekly (UTC). Coverage is expensive; not required on every PR.
+    - cron: '0 5 * * 1' # Mondays 05:00 UTC
+  workflow_dispatch: {}
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -31,6 +31,7 @@ jobs:
       - name: Clippy
         working-directory: codex-rs
         continue-on-error: true
+        if: github.event_name == 'push'
         run: cargo clippy -p codex-cli -p codex-tui --all-targets --no-deps
 
       - name: Tests (core)
@@ -40,6 +41,10 @@ jobs:
       - name: Tests (tui lib)
         working-directory: codex-rs
         run: cargo test -p codex-tui --lib
+
+      - name: Build (code binary)
+        working-directory: codex-rs
+        run: cargo build -p codex-cli --bin code
 
       - name: Docs link check
         run: python3 scripts/check_doc_links.py

--- a/.github/workflows/tui-tests.yml
+++ b/.github/workflows/tui-tests.yml
@@ -8,13 +8,6 @@ on:
       - 'codex-rs/core/**'
       - 'codex-rs/protocol/**'
       - '.github/workflows/tui-tests.yml'
-  pull_request:
-    branches: [ main ]
-    paths:
-      - 'codex-rs/tui/**'
-      - 'codex-rs/core/**'
-      - 'codex-rs/protocol/**'
-      - '.github/workflows/tui-tests.yml'
 
 env:
   CARGO_TERM_COLOR: always

--- a/docs/briefs/fix__ci-linux-only-weekly.md
+++ b/docs/briefs/fix__ci-linux-only-weekly.md
@@ -1,0 +1,23 @@
+# Session Brief — fix/ci-linux-only-weekly
+
+## Goal
+
+## Scope / Constraints
+
+## Plan
+
+## Open Questions
+
+## Verification
+
+<!-- BEGIN: SPECKIT_BRIEF_REFRESH -->
+## Product Knowledge (auto)
+
+- Query: `CI linux-only PR checks: tests + build; move heavy jobs (coverage, preview build) to weekly schedule`
+- Domain: `codex-product`
+- Capsule URI: `mv2://default/WORKFLOW/brief-20260205T213440Z/artifact/briefs/fix__ci-linux-only-weekly/20260205T213440Z.md`
+- Capsule checkpoint: `brief-fix__ci-linux-only-weekly-20260205T213440Z`
+
+No high-signal product knowledge matched. Try a more specific `--query` and/or raise `--limit`.
+
+<!-- END: SPECKIT_BRIEF_REFRESH -->


### PR DESCRIPTION
Summary:
- PR CI now runs only `Quality Gates` (Linux)
- Drops per-PR `TUI Tests` and `Code Coverage` (kept as push-main / weekly)
- `Quality Gates` now also builds the `code` binary

Policy/Decisions:
- Proposed (user-confirmed): Linux-only CI + weekly preview build

Validation:
- `bash .githooks/pre-commit`
- `python3 scripts/doc_lint.py`
- `python3 scripts/check_doc_links.py`