### PR TITLE
docs(pm): expand web research template

### DIFF
--- a/docs/SPEC-PM-001-project-management/PRD.md
+++ b/docs/SPEC-PM-001-project-management/PRD.md
@@ -203,9 +203,16 @@ All web research used to form recommendations should be captured into capsule ar
 **Capture-mode rules**
 
 - `prompts_only` (export-safe):
-  - Store query + params and **URL list**.
-  - Do **not** store extracted page text.
-  - If storing result snippets is deemed unsafe, store only hashes for title/snippet instead of raw text.
+  - Store query + params and a **full result template** (not just titles):
+    - URL + domain
+    - title (if available)
+    - ranking/score (if provided)
+    - published/updated timestamp (if available)
+    - snippet/summary fields (if provided), with size caps
+    - hashes for any larger text fields to support audit/replay without requiring raw storage
+  - Optionally store a **temporary non-export-safe cache** for selected sources to avoid refetching during the same session:
+    - extracted content is stored separately (by URI) with explicit TTL/expiry metadata
+    - cache artifacts must be excluded from safe export and are not required for deterministic gating
 - `full_io` (not export-safe):
   - May store extracted page text as separate capsule artifacts referenced by URI.
 
@@ -247,7 +254,7 @@ All web research used to form recommendations should be captured into capsule ar
 - Whether `docs/DEPRECATIONS.md` becomes a projection of capsule events in the first iteration or later.
 - How to represent “archived packs” as first-class capsule artifacts (URI scheme, metadata).
 - Confirm deterministic scoring rubric weights/threshold behavior (see "Deterministic PRD Quality Score").
-- Confirm web research artifact export-safety posture (snippets/titles stored vs hashed-only in `prompts_only`).
+- Confirm web research template size caps + cache retention/TTL for `prompts_only` temporary content cache.
 - What automation "bot runner" semantics exist for `NeedsResearch` / `NeedsReview` (manual-only state vs queue semantics, scheduling, visibility in status surfaces).
 
 ---

--- a/docs/briefs/fix__pm-web-research-template.md
+++ b/docs/briefs/fix__pm-web-research-template.md
@@ -1,0 +1,30 @@
+# Session Brief
+
+**Branch**: fix/pm-web-research-template
+**Date**: 2026-02-06
+
+## Intent
+
+Expand the WebResearchBundle artifact template beyond titles/snippets, including a temporary cache strategy, while preserving export safety and capture-mode semantics.
+
+## Constraints
+
+- D133 parity + headless never prompts.
+- Capture modes: none | prompts_only | full_io.
+
+## Verification
+
+- python3 scripts/doc_lint.py
+- python3 scripts/check_doc_links.py
+- bash .githooks/pre-commit
+<!-- BEGIN: SPECKIT_BRIEF_REFRESH -->
+## Product Knowledge (auto)
+
+- Query: `SPEC-PM-001: expand web research artifact template beyond titles/snippets; add temporary cache strategy; preserve export safety`
+- Domain: `codex-product`
+- Capsule URI: `mv2://default/WORKFLOW/brief-20260207T015316Z/artifact/briefs/fix__pm-web-research-template/20260207T015316Z.md`
+- Capsule checkpoint: `brief-fix__pm-web-research-template-20260207T015316Z`
+
+No high-signal product knowledge matched. Try a more specific `--query` and/or raise `--limit`.
+
+<!-- END: SPECKIT_BRIEF_REFRESH -->


### PR DESCRIPTION
Summary:
- Expand `WebResearchBundle` prompts_only guidance to capture a fuller result template (beyond titles/snippets) while remaining export-safe.
- Add optional temporary non-export-safe cache guidance for selected sources (explicit TTL/expiry; excluded from safe export).

Validation:
- `python3 scripts/doc_lint.py`
- `python3 scripts/check_doc_links.py`
- `bash .githooks/pre-commit`