### PR TITLE
docs(pm): add SPEC-PM-002 bot runner stub

### DIFF
--- a/DEV_BRIEF.md
+++ b/DEV_BRIEF.md
@@ -2,11 +2,11 @@
 
 > **Tier-1 Truth Anchor** — Required for every session. Update before starting work.
 
-**Last Updated**: 2026-02-03
+**Last Updated**: 2026-02-07
 
 ## Current Focus
 
-Idle
+Docs-only planning stub: `SPEC-PM-002` (Devin-style bot runner semantics for `NeedsResearch` / `NeedsReview`)
 
 ## Session Workflow
 

--- a/codex-rs/SPEC.md
+++ b/codex-rs/SPEC.md
@@ -1,7 +1,7 @@
 # SPEC.md - Codex-RS / Spec-Kit Task Tracking
 
 **Version:** V6 Docs Contract
-**Last Updated:** 2026-02-05
+**Last Updated:** 2026-02-07
 
 ***
 
@@ -111,6 +111,7 @@ These invariants MUST NOT be violated:
 | SPEC-DOGFOOD-002 | Canonical gold run: prove `/speckit.auto` happy path + complete evidence chain on Linux; add a scheduled CI run once stable. |
 | SPEC-PK-001 | Product knowledge (codex-product) dogfood + measurement: validate determinism (snapshot/evidence pack) and quantify Tier2 reduction/curation quality. |
 | SPEC-PM-001 | Project management deep dive: capsule-backed feature + task tracking (SoR) with filesystem projections (including `SPEC.md`), maieutic PRD sessions, and status surfaces (CLI/TUI/headless). PRD: `docs/SPEC-PM-001-project-management/PRD.md`. |
+| SPEC-PM-002 | Devin-style bot runner semantics: manual research/review automation triggered via `NeedsResearch` / `NeedsReview` holding states. Stub: `docs/SPEC-PM-002-bot-runner/spec.md`. |
 | DOC-DRIFT-001 | Docs drift control: maintain `docs/DEPRECATIONS.md`, deprecate/update legacy PRDs/roadmaps that conflict with current product vision, and keep doc maps pointing at canonical trackers. |
 
 ### Completed (Recent)

--- a/docs/SPEC-PM-001-project-management/PRD.md
+++ b/docs/SPEC-PM-001-project-management/PRD.md
@@ -255,11 +255,11 @@ All web research used to form recommendations should be captured into capsule ar
 - How to represent “archived packs” as first-class capsule artifacts (URI scheme, metadata).
 - Confirm deterministic scoring rubric weights/threshold behavior (see "Deterministic PRD Quality Score").
 - Confirm web research template size caps + cache retention/TTL for `prompts_only` temporary content cache.
-- What automation "bot runner" semantics exist for `NeedsResearch` / `NeedsReview` (manual-only state vs queue semantics, scheduling, visibility in status surfaces).
+- Bot runner semantics for `NeedsResearch` / `NeedsReview` (manual-only state vs queue semantics, scheduling, visibility in status surfaces) — tracked as `SPEC-PM-002`.
 
 ---
 
 ## Supporting Docs
 
 - `docs/SPEC-PM-001-project-management/ARCHITECT-BRIEF-maieutic-and-prd.md`: research + design drift analysis for assisted maieutics and PRD generation.
-- `docs/SPEC-PM-001-project-management/TODO-bot-runner-spec.md`: TODO spec stub for Devin-style research/review bot runner semantics.
+- `docs/SPEC-PM-002-bot-runner/spec.md`: SPEC stub for Devin-style research/review bot runner semantics.

--- a/docs/SPEC-PM-001-project-management/TODO-bot-runner-spec.md
+++ b/docs/SPEC-PM-001-project-management/TODO-bot-runner-spec.md
@@ -1,8 +1,12 @@
 # TODO Spec: Devin-Style Bot Runner (NeedsResearch / NeedsReview)
 
-**Status**: Draft (TODO)
+**Status**: Superseded by `SPEC-PM-002` (2026-02-07)
 **Parent**: `SPEC-PM-001`
 **Date**: 2026-02-06
+
+This file is kept for historical context. Canonical stub now lives at:
+
+- `docs/SPEC-PM-002-bot-runner/spec.md`
 
 ---
 
@@ -78,4 +82,3 @@ All artifacts must respect capture mode (`none | prompts_only | full_io`) and ex
   - `WebResearchBundle` + a short `ResearchReport` (structured JSON + Markdown projection).
 - A command to place an item into `NeedsReview` and run a single deterministic/static review pass that emits:
   - `ReviewReport` with "must fix" vs "suggestions" plus a summarized risk list.
-

--- a/docs/SPEC-PM-002-bot-runner/spec.md
+++ b/docs/SPEC-PM-002-bot-runner/spec.md
@@ -1,0 +1,71 @@
+# SPEC-PM-002: Devin-Style Bot Runner (NeedsResearch / NeedsReview)
+
+## Status: PLANNED (stub)
+
+## Overview
+
+Define the product semantics and Tier‑1 command surfaces for **manual** "Devin-style" automation bots that a PM can trigger by placing a work item into:
+
+- `NeedsResearch` (run research bots)
+- `NeedsReview` (run review bots)
+
+This SPEC is intentionally **not** part of the default automatic workflow; it is an explicit/manual state transition used for optional automation.
+
+## Goals
+
+- Define minimum viable behaviors for:
+  - Research bots (`NeedsResearch`)
+  - Review bots (`NeedsReview`)
+- Define artifacts produced and how they are persisted to capsule + projected to filesystem.
+- Define CLI/TUI/headless commands to trigger runs and to view results (Tier‑1 parity).
+- Define headless behavior contract (structured output + product exit codes; never prompt).
+- Define tool and safety boundaries for bot runs (what can be read/executed).
+
+## Non-Goals (initial)
+
+- Running bots automatically on every PR/spec by default.
+- Cross-platform support (Linux-only remains baseline).
+- Fully autonomous implementation execution (coding/committing/merging) as a default mode.
+
+## Inputs
+
+- Work item + attached PRD/intake form data.
+- Local product knowledge artifacts (default); optional NotebookLM escalation (configurable).
+- Web research via Tavily MCP (default; pinned locally), with fallback to client default web research when Tavily is unavailable.
+
+## Outputs (Artifacts)
+
+Proposed artifact types (names and schemas TBD in this SPEC):
+
+- `ResearchReport`: web research bundle + synthesis + recommended options/tradeoffs.
+- `ReviewReport`: structured review notes with file/line references + risk assessment.
+- `BotRunLog`: timing/cost summary + tool usage + success/failure diagnostics.
+
+All artifacts must respect capture mode (`none | prompts_only | full_io`) and export safety constraints (locked by policy).
+
+## Tier‑1 Constraints (Already Locked)
+
+- **Multi-surface parity** (D133): CLI/TUI/headless must share semantics for Tier‑1 behavior.
+- **Headless never prompts** (D133): missing required inputs must return product exit codes + structured output.
+- **Maieutic step is mandatory for `/speckit.auto`** (D130): bot runner must not create a bypass of required gates.
+
+## Minimal MVP (suggested)
+
+- A command to place an item into `NeedsResearch` and run a single research pass that emits:
+  - `WebResearchBundle` + a short `ResearchReport` (structured JSON + Markdown projection).
+- A command to place an item into `NeedsReview` and run a single deterministic/static review pass that emits:
+  - `ReviewReport` with "must fix" vs "suggestions" plus a summarized risk list.
+
+## Definition of Done
+
+- PRD/design doc produced for this SPEC with:
+  - Bot runner execution model (on-demand vs queued), idempotency, and visibility in status surfaces.
+  - Artifact schemas + filesystem projection locations.
+  - Command surface proposal under `code speckit pm ...` (plus TUI alias mapping 1:1).
+  - Headless exit-code + JSON contract for bot runs.
+  - Safety boundaries (tool allowlist) and capture-mode compliance.
+
+## References
+
+- PM system PRD: `docs/SPEC-PM-001-project-management/PRD.md`
+- Historical stub: `docs/SPEC-PM-001-project-management/TODO-bot-runner-spec.md`

--- a/docs/briefs/docs__spec-pm-002-bot-runner.md
+++ b/docs/briefs/docs__spec-pm-002-bot-runner.md
@@ -1,0 +1,38 @@
+# Session Brief — docs/spec-pm-002-bot-runner
+
+## Goal
+
+Create and track a dedicated SPEC for Devin-style research/review automation bots (manual-only PM holding states).
+
+## Scope / Constraints
+
+- Docs-only changes (no Rust changes in this PR).
+- Linux-only assumptions; no cross-platform commitments.
+
+## Plan
+
+- Add `SPEC-PM-002` doc stub under `docs/`.
+- Add a `codex-rs/SPEC.md` Planned row for `SPEC-PM-002`.
+- Keep `SPEC-PM-001` PRD pointers consistent.
+
+## Open Questions
+
+## Verification
+
+Run local doc gates:
+
+- `python3 scripts/doc_lint.py`
+- `python3 scripts/check_doc_links.py`
+- `bash .githooks/pre-commit`
+
+<!-- BEGIN: SPECKIT_BRIEF_REFRESH -->
+## Product Knowledge (auto)
+
+- Query: `SPEC-PM-002 bot runner devin-style needsresearch needsreview`
+- Domain: `codex-product`
+- Capsule URI: `mv2://default/WORKFLOW/brief-20260207T023054Z/artifact/briefs/docs__spec-pm-002-bot-runner/20260207T023054Z.md`
+- Capsule checkpoint: `brief-docs__spec-pm-002-bot-runner-20260207T023054Z`
+
+No high-signal product knowledge matched. Try a more specific `--query` and/or raise `--limit`.
+
+<!-- END: SPECKIT_BRIEF_REFRESH -->


### PR DESCRIPTION
Summary:
- Add `SPEC-PM-002` stub for Devin-style research/review bot runner semantics (`NeedsResearch`/`NeedsReview`).
- Track `SPEC-PM-002` in `codex-rs/SPEC.md` Planned table and update `SPEC-PM-001` PRD pointers.

Verification (local):
- `python3 scripts/doc_lint.py`
- `python3 scripts/check_doc_links.py`
- `bash .githooks/pre-commit`