### PR TITLE
docs(pm): pin bot runner semantics

### DIFF
--- a/docs/SPEC-PM-001-project-management/PRD.md
+++ b/docs/SPEC-PM-001-project-management/PRD.md
@@ -57,10 +57,10 @@ This is a product vision gap: the same tools used to build Codex-RS should also 
 Work items have a single **state** at a time:
 
 - `Backlog`: Not scheduled yet (default for new work items).
-- `NeedsResearch`: Optional manual holding state to run "Devin-style" research automation.
+- `NeedsResearch`: Optional manual holding state to run "Devin-style" research automation (semantics tracked in `SPEC-PM-002`; NotebookLM-required).
 - `Planned`: Scheduled / approved to start. Promotion to `Planned` is explicitly invoked and gated (see below).
 - `InProgress`: Actively being worked.
-- `NeedsReview`: Optional manual holding state to run "Devin-style" review automation.
+- `NeedsReview`: Optional manual holding state to run "Devin-style" review automation (semantics tracked in `SPEC-PM-002`).
 - `Completed`: Done (definition depends on item type; for specs, typically "merged + verified").
 - `Deprecated`: No longer applicable to product direction; retained for history with pointers.
 - `Archived`: Terminal historical record (kept only as a pointer + archived pack).
@@ -94,6 +94,19 @@ Promotion to `Planned` is **manual** (PM action) and must satisfy:
    - If open questions are present, the work item cannot be marked `Planned`.
 
 Headless must return structured output and product exit codes for blocking states (no clap default exit=2 fallbacks).
+
+---
+
+## Bot Automation Holding States (v1) — tracked in `SPEC-PM-002`
+
+These are **manual** states used for optional automation (not part of the default `/speckit.auto` workflow):
+
+- `NeedsResearch`:
+  - **NotebookLM is required**; if unavailable, the run returns a BLOCKED result with structured output (no fallback research).
+  - Network access is allowed (Tavily MCP preferred; generic web research allowed).
+- `NeedsReview`:
+  - Validator/reviewer runs with tool access and may create worktrees/branches to stage suggested changes.
+  - Bot output must be able to write back a summarized response into TUI status surfaces.
 
 ---
 

--- a/docs/SPEC-PM-002-bot-runner/spec.md
+++ b/docs/SPEC-PM-002-bot-runner/spec.md
@@ -11,6 +11,8 @@ Define the product semantics and Tier‑1 command surfaces for **manual** "Devin
 
 This SPEC is intentionally **not** part of the default automatic workflow; it is an explicit/manual state transition used for optional automation.
 
+This automation is expected to be **in-depth** and may need to evolve into a dedicated “bot system” (runner/service/tooling) tracked separately from the PM semantics (see Open Questions).
+
 ## Goals
 
 - Define minimum viable behaviors for:
@@ -25,13 +27,16 @@ This SPEC is intentionally **not** part of the default automatic workflow; it is
 
 - Running bots automatically on every PR/spec by default.
 - Cross-platform support (Linux-only remains baseline).
-- Fully autonomous implementation execution (coding/committing/merging) as a default mode.
+- Auto-committing/pushing/merging as a default mode.
 
 ## Inputs
 
 - Work item + attached PRD/intake form data.
-- Local product knowledge artifacts (default); optional NotebookLM escalation (configurable).
-- Web research via Tavily MCP (default; pinned locally), with fallback to client default web research when Tavily is unavailable.
+- Capsule artifacts linked to the work item (intake/grounding/reports/evidence).
+- NotebookLM is **required** for `NeedsResearch` runs; if unavailable, the run hard-fails as **BLOCKED** with structured output (no fallback research).
+- Web research is allowed via both:
+  - Tavily MCP (preferred; pinned locally), and
+  - the client’s default/generic web research tooling.
 
 ## Outputs (Artifacts)
 
@@ -42,6 +47,13 @@ Proposed artifact types (names and schemas TBD in this SPEC):
 - `BotRunLog`: timing/cost summary + tool usage + success/failure diagnostics.
 
 All artifacts must respect capture mode (`none | prompts_only | full_io`) and export safety constraints (locked by policy).
+
+## Execution Model (v1)
+
+- Implemented as a **background service spawned by the TUI** (tertiary service).
+- Must still provide Tier‑1 parity across CLI/TUI/headless for automation-critical behavior (commands, artifacts, gating semantics, exit codes).
+- Validator/reviewer bot may create **worktrees/branches** to stage suggested changes and persist patch context.
+- Bot results must be able to write back a summarized response into the main TUI conversation/status surfaces.
 
 ## Tier‑1 Constraints (Already Locked)
 
@@ -60,10 +72,17 @@ All artifacts must respect capture mode (`none | prompts_only | full_io`) and ex
 
 - PRD/design doc produced for this SPEC with:
   - Bot runner execution model (on-demand vs queued), idempotency, and visibility in status surfaces.
+  - NotebookLM hard dependency behavior for `NeedsResearch` (blocked exit code + structured output; no fallback).
+  - Worktree/branch creation semantics and write boundaries (what may be written, and what is forbidden by default).
+  - TUI write-back mechanism for bot outputs (status/events + report linking).
   - Artifact schemas + filesystem projection locations.
   - Command surface proposal under `code speckit pm ...` (plus TUI alias mapping 1:1).
   - Headless exit-code + JSON contract for bot runs.
   - Safety boundaries (tool allowlist) and capture-mode compliance.
+
+## Open Questions
+
+- Should the “bot runner/service” be tracked as its own dedicated SPEC (separate from PM semantics), with `SPEC-PM-002` focused on product semantics and surfaces?
 
 ## References
 

--- a/docs/briefs/docs__pm-bot-runner-semantics.md
+++ b/docs/briefs/docs__pm-bot-runner-semantics.md
@@ -1,0 +1,39 @@
+# Session Brief — docs/pm-bot-runner-semantics
+
+## Goal
+
+Update `SPEC-PM-001` / `SPEC-PM-002` docs to reflect confirmed bot-runner semantics (NotebookLM hard requirement for `NeedsResearch`, validator tool+write access, background service spawned by TUI, and web-research allowances).
+
+## Scope / Constraints
+
+- Docs-only (no Rust changes).
+- Tier‑1 parity + headless never prompts remain locked constraints (D133).
+- Linux-only expectations.
+
+## Plan
+
+- Update `docs/SPEC-PM-001-project-management/PRD.md` to reference the pinned `SPEC-PM-002` semantics.
+- Update `docs/SPEC-PM-002-bot-runner/spec.md` to capture the confirmed execution model + tool/write boundaries.
+- Run doc gates + pre-commit, then PR + merge.
+
+## Open Questions
+
+- Should the in-depth bot automation system be tracked as its own dedicated SPEC/project (separate from PM semantics)?
+
+## Verification
+
+- `python3 scripts/doc_lint.py`
+- `python3 scripts/check_doc_links.py`
+- `bash .githooks/pre-commit`
+
+<!-- BEGIN: SPECKIT_BRIEF_REFRESH -->
+## Product Knowledge (auto)
+
+- Query: `SPEC-PM-002 needsresearch needsreview notebooklm hard fail validator bot service worktree branch`
+- Domain: `codex-product`
+- Capsule URI: `mv2://default/WORKFLOW/brief-20260207T030318Z/artifact/briefs/docs__pm-bot-runner-semantics/20260207T030318Z.md`
+- Capsule checkpoint: `brief-docs__pm-bot-runner-semantics-20260207T030318Z`
+
+No high-signal product knowledge matched. Try a more specific `--query` and/or raise `--limit`.
+
+<!-- END: SPECKIT_BRIEF_REFRESH -->


### PR DESCRIPTION
Summary:
- Pin confirmed semantics for `NeedsResearch`/`NeedsReview` bot automation (NotebookLM hard requirement, BLOCKED on NLM unavailable, validator tool+write access incl. worktree/branch, TUI write-back, web research allowed via Tavily + generic).
- Keep details tracked in `SPEC-PM-002`.

Verification (local):
- `python3 scripts/doc_lint.py`
- `python3 scripts/check_doc_links.py`
- `bash .githooks/pre-commit`