### PR TITLE
docs(pm): split bot runner interface vs system

### DIFF
--- a/DEV_BRIEF.md
+++ b/DEV_BRIEF.md
@@ -6,7 +6,7 @@
 
 ## Current Focus
 
-Docs-only planning stub: `SPEC-PM-002` (Devin-style bot runner semantics for `NeedsResearch` / `NeedsReview`)
+Docs-only planning: `SPEC-PM-002` (bot runner interface contract) + `SPEC-PM-003` (bot system design) for `NeedsResearch` / `NeedsReview`
 
 ## Session Workflow
 

--- a/codex-rs/SPEC.md
+++ b/codex-rs/SPEC.md
@@ -111,7 +111,8 @@ These invariants MUST NOT be violated:
 | SPEC-DOGFOOD-002 | Canonical gold run: prove `/speckit.auto` happy path + complete evidence chain on Linux; add a scheduled CI run once stable. |
 | SPEC-PK-001 | Product knowledge (codex-product) dogfood + measurement: validate determinism (snapshot/evidence pack) and quantify Tier2 reduction/curation quality. |
 | SPEC-PM-001 | Project management deep dive: capsule-backed feature + task tracking (SoR) with filesystem projections (including `SPEC.md`), maieutic PRD sessions, and status surfaces (CLI/TUI/headless). PRD: `docs/SPEC-PM-001-project-management/PRD.md`. |
-| SPEC-PM-002 | Devin-style bot runner semantics: manual research/review automation triggered via `NeedsResearch` / `NeedsReview` holding states. Stub: `docs/SPEC-PM-002-bot-runner/spec.md`. |
+| SPEC-PM-002 | Bot runner interface contract: commands + headless exit codes + artifacts for manual `NeedsResearch` / `NeedsReview` runs. Spec: `docs/SPEC-PM-002-bot-runner/spec.md`. |
+| SPEC-PM-003 | Bot system design: runner/service/tooling implementation for `NeedsResearch` / `NeedsReview` automation (queueing, permissions, worktrees, projections). Spec: `docs/SPEC-PM-003-bot-system/spec.md`. |
 | DOC-DRIFT-001 | Docs drift control: maintain `docs/DEPRECATIONS.md`, deprecate/update legacy PRDs/roadmaps that conflict with current product vision, and keep doc maps pointing at canonical trackers. |
 
 ### Completed (Recent)

--- a/docs/SPEC-PM-001-project-management/PRD.md
+++ b/docs/SPEC-PM-001-project-management/PRD.md
@@ -97,7 +97,7 @@ Headless must return structured output and product exit codes for blocking state
 
 ---
 
-## Bot Automation Holding States (v1) — tracked in `SPEC-PM-002`
+## Bot Automation Holding States (v1) — tracked in `SPEC-PM-002` / `SPEC-PM-003`
 
 These are **manual** states used for optional automation (not part of the default `/speckit.auto` workflow):
 
@@ -107,6 +107,10 @@ These are **manual** states used for optional automation (not part of the defaul
 - `NeedsReview`:
   - Validator/reviewer runs with tool access and may create worktrees/branches to stage suggested changes.
   - Bot output must be able to write back a summarized response into TUI status surfaces.
+
+See:
+- Interface contract (commands/exit codes/artifacts): `docs/SPEC-PM-002-bot-runner/spec.md`
+- Bot system design (runner/service/tooling internals): `docs/SPEC-PM-003-bot-system/spec.md`
 
 ---
 
@@ -268,7 +272,7 @@ All web research used to form recommendations should be captured into capsule ar
 - How to represent “archived packs” as first-class capsule artifacts (URI scheme, metadata).
 - Confirm deterministic scoring rubric weights/threshold behavior (see "Deterministic PRD Quality Score").
 - Confirm web research template size caps + cache retention/TTL for `prompts_only` temporary content cache.
-- Bot runner semantics for `NeedsResearch` / `NeedsReview` (manual-only state vs queue semantics, scheduling, visibility in status surfaces) — tracked as `SPEC-PM-002`.
+- Bot runner interface + system design for `NeedsResearch` / `NeedsReview` (manual-only state vs queue semantics, scheduling, visibility in status surfaces) — tracked as `SPEC-PM-002` / `SPEC-PM-003`.
 
 ---
 

--- a/docs/SPEC-PM-002-bot-runner/spec.md
+++ b/docs/SPEC-PM-002-bot-runner/spec.md
@@ -1,65 +1,230 @@
-# SPEC-PM-002: Devin-Style Bot Runner (NeedsResearch / NeedsReview)
+# SPEC-PM-002: Bot Runner Interface (NeedsResearch / NeedsReview)
 
-## Status: PLANNED (stub)
+## Status: PLANNED (interface contract)
 
 ## Overview
 
-Define the product semantics and Tier‑1 command surfaces for **manual** "Devin-style" automation bots that a PM can trigger by placing a work item into:
+Define the **product semantics** and Tier‑1 **interaction contract** for manual “Devin-style” automation bots that a PM can trigger by placing a work item into:
 
 - `NeedsResearch` (run research bots)
-- `NeedsReview` (run review bots)
+- `NeedsReview` (run review/validator bots)
 
-This SPEC is intentionally **not** part of the default automatic workflow; it is an explicit/manual state transition used for optional automation.
+This document is intentionally an **interface spec**: how callers interact with bot runs (CLI/TUI/headless), what inputs are required, what outputs/artifacts are produced, and what safety/exit-code guarantees are provided.
 
-This automation is expected to be **in-depth** and may need to evolve into a dedicated “bot system” (runner/service/tooling) tracked separately from the PM semantics (see Open Questions).
+The underlying **bot system architecture** (runner/service/tooling internals, queueing, IPC, allowlists) is tracked separately in `SPEC-PM-003`.
+
+## Definitions (v1)
+
+- **Work Item**: A capsule-backed PM object with a stable ID and lifecycle state (defined in `SPEC-PM-001`).
+- **Bot Kind**: `research | review`
+- **Bot Run**: A single execution of a bot kind against a specific work item, identified by a unique `run_id`.
+- **Write Mode** (review only): `none | worktree`
+  - `none`: bot is read-only with respect to the repo
+  - `worktree`: bot may stage suggested changes in a bot-owned worktree/branch
+- **Artifact URI**: A capsule logical URI referencing an immutable artifact (authoritative SoR).
+- **Filesystem Projection**: Best-effort human-readable mirror of artifacts; rebuildable from capsule state (not authoritative).
 
 ## Goals
 
-- Define minimum viable behaviors for:
+- Define the minimum viable behaviors for:
   - Research bots (`NeedsResearch`)
   - Review bots (`NeedsReview`)
-- Define artifacts produced and how they are persisted to capsule + projected to filesystem.
-- Define CLI/TUI/headless commands to trigger runs and to view results (Tier‑1 parity).
+- Define Tier‑1 command surfaces (CLI/TUI/headless) and required parity.
 - Define headless behavior contract (structured output + product exit codes; never prompt).
-- Define tool and safety boundaries for bot runs (what can be read/executed).
+- Define safety boundaries as caller-visible guarantees (read-only default; write mode isolation).
+- Define artifacts produced and their projection expectations.
 
 ## Non-Goals (initial)
 
+- Defining the internal runner/service architecture (tracked in `SPEC-PM-003`).
 - Running bots automatically on every PR/spec by default.
 - Cross-platform support (Linux-only remains baseline).
 - Auto-committing/pushing/merging as a default mode.
+- Auto-transitioning PM lifecycle states (state changes remain an explicit PM action).
+
+## Tier‑1 Constraints (Already Locked)
+
+- **Multi-surface parity** (D113/D133): CLI/TUI/headless must share semantics for Tier‑1 behavior (commands, artifacts, gating semantics, exit codes).
+- **Headless never prompts** (D133): missing requirements must return product exit codes + structured output.
+- **Maieutic step always mandatory** (D130): bot automation must not create a bypass for required gates (especially `/speckit.auto`).
+- **Explainability follows capture mode** (D131) + **over-capture is hard-blocked** (D119): artifacts must never exceed policy capture bounds; `capture=none` persists no explainability artifacts.
+- **No silent destructive actions in headless** (NFR3 in `SPEC-PM-001`): write actions must be explicit and auditable.
+
+## Product Semantics (v1)
+
+### Manual Holding States
+
+- `NeedsResearch` and `NeedsReview` are **manual holding states** in the PM lifecycle (defined in `SPEC-PM-001`).
+- Entering a holding state does **not** automatically start a bot; it only makes the item eligible for a manual bot run.
+
+### State Transition Rules (v1)
+
+- Bot runs do **not** automatically move a work item out of `NeedsResearch`/`NeedsReview`.
+- A bot run may recommend a next state (e.g. “return to Backlog”, “promote to Planned”), but the PM performs the state change explicitly.
+
+### Visibility (Tier‑1)
+
+- The current holding state and the latest bot run summary must be visible across CLI/TUI/headless status surfaces.
+- Long-form details live in artifacts (capsule SoR) with projections for humans.
 
 ## Inputs
 
 - Work item + attached PRD/intake form data.
 - Capsule artifacts linked to the work item (intake/grounding/reports/evidence).
-- NotebookLM is **required** for `NeedsResearch` runs; if unavailable, the run hard-fails as **BLOCKED** with structured output (no fallback research).
+- `NeedsResearch` requires NotebookLM; if unavailable/unconfigured, the run terminates as **BLOCKED** with structured output (no fallback research).
 - Web research is allowed via both:
   - Tavily MCP (preferred; pinned locally), and
   - the client’s default/generic web research tooling.
 
 ## Outputs (Artifacts)
 
-Proposed artifact types (names and schemas TBD in this SPEC):
+Artifact types (schemas start at v0; additive-only until locked):
 
-- `ResearchReport`: web research bundle + synthesis + recommended options/tradeoffs.
+- `ResearchReport`: synthesis + recommended options/tradeoffs (references `WebResearchBundle` as needed).
 - `ReviewReport`: structured review notes with file/line references + risk assessment.
 - `BotRunLog`: timing/cost summary + tool usage + success/failure diagnostics.
+- `WebResearchBundle`: structured web research capture (defined in `SPEC-PM-001`; reused here).
+- `PatchBundle` (review only, write mode): patch/diff + worktree/branch metadata + apply/inspect instructions.
 
 All artifacts must respect capture mode (`none | prompts_only | full_io`) and export safety constraints (locked by policy).
 
-## Execution Model (v1)
+## Command Surface (Tier‑1, proposal)
 
-- Implemented as a **background service spawned by the TUI** (tertiary service).
-- Must still provide Tier‑1 parity across CLI/TUI/headless for automation-critical behavior (commands, artifacts, gating semantics, exit codes).
-- Validator/reviewer bot may create **worktrees/branches** to stage suggested changes and persist patch context.
-- Bot results must be able to write back a summarized response into the main TUI conversation/status surfaces.
+> Canonical CLI namespace remains: `code speckit pm ...` (see `SPEC-PM-001`).
 
-## Tier‑1 Constraints (Already Locked)
+### Run
 
-- **Multi-surface parity** (D133): CLI/TUI/headless must share semantics for Tier‑1 behavior.
-- **Headless never prompts** (D133): missing required inputs must return product exit codes + structured output.
-- **Maieutic step is mandatory for `/speckit.auto`** (D130): bot runner must not create a bypass of required gates.
+- `code speckit pm bot run --id <WORK_ITEM_ID> --kind research`
+- `code speckit pm bot run --id <WORK_ITEM_ID> --kind review [--write-mode worktree]`
+
+### Status + Results
+
+- `code speckit pm bot status --id <WORK_ITEM_ID> [--json]`
+- `code speckit pm bot runs --id <WORK_ITEM_ID> [--limit N] [--json]`
+- `code speckit pm bot show --id <WORK_ITEM_ID> --run <RUN_ID> [--format md|json]`
+
+### TUI Aliases (Tier‑1 parity)
+
+- `/pm bot run <WORK_ITEM_ID> research`
+- `/pm bot run <WORK_ITEM_ID> review`
+- `/pm bot show <WORK_ITEM_ID> <RUN_ID>`
+
+## Safety + Write Modes (caller-visible contract)
+
+### Default
+
+- Default is **read-only** with respect to the repo.
+- Bot runs must never commit/push/merge by default.
+
+### Review Write Mode: `worktree`
+
+When `--write-mode worktree` is enabled for `NeedsReview` runs:
+
+- All changes are staged in a bot-owned worktree/branch (the user’s primary working tree is not modified by default).
+- The run result must include:
+  - `worktree_path` (if created)
+  - `branch_name` (if created)
+  - A `PatchBundle` artifact URI containing a diff/patch reference and safe apply/inspect instructions
+
+Worktree/branch naming conventions and enforcement details are specified in `SPEC-PM-003`.
+
+## Headless Contract (Tier‑1, proposal)
+
+### Never Prompt
+
+- Headless mode must never prompt (D133). Missing requirements must return:
+  - A non-zero exit code, and
+  - Structured JSON describing the missing requirement and resolution steps.
+
+### Exit Codes (proposal)
+
+Bot runs should reuse the existing semantics of standard + headless-specific exit codes:
+
+- `0`: success (run completed)
+- `2`: hard fail / blocked (includes `NotebookLM unavailable` for `NeedsResearch`)
+- `3`: infrastructure error (runner/service failure, I/O, capsule corruption)
+- `10`: needs input (missing required work item data / work item not eligible / missing required flags)
+- `11`: needs approval (write-mode requested but not explicitly allowed in headless policy/config)
+- `13`: invariant violation (headless attempted to prompt)
+
+### JSON Output Schema (v0)
+
+All headless bot-run commands must emit JSON with:
+
+- `schema_version`
+- `tool_version`
+- `work_item_id`
+- `kind` (`research | review`)
+- `run_id`
+- `status` (`success | failed | blocked | cancelled`)
+- `exit_code`
+- `summary` (short, human-readable)
+- `artifact_uris[]` (capsule logical URIs for produced artifacts)
+- `projection_paths[]` (filesystem projections written, if any)
+- `errors[]` (structured; includes `blocked_reason` for `status=blocked`)
+
+## Artifact Schemas (v0 — proposal)
+
+### BotRunLog
+
+- `schema_version`
+- `tool_version`
+- `work_item_id`, `run_id`, `kind`
+- `started_at`, `finished_at`, `duration_ms`
+- `capture_mode`
+- `tool_usage[]` (tool name + counts + timing; no over-capture)
+- `status` + `errors[]`
+
+### ResearchReport
+
+- `schema_version`
+- `tool_version`
+- `work_item_id`, `run_id`
+- `inputs` (artifact URIs used)
+- `executive_summary`
+- `options[]` (each with tradeoffs + recommendation)
+- `open_questions[]`
+- `citations[]` (references into `WebResearchBundle` entries)
+
+### ReviewReport
+
+- `schema_version`
+- `tool_version`
+- `work_item_id`, `run_id`
+- `summary`
+- `must_fix[]` (file/line references + rationale)
+- `suggestions[]`
+- `risks[]`
+- `commands_ran[]` (allowlisted command record)
+- `patch_bundle_uri` (optional)
+
+### PatchBundle (review, write mode only)
+
+- `schema_version`
+- `tool_version`
+- `work_item_id`, `run_id`
+- `worktree_path` (if created)
+- `branch_name` (if created)
+- `diff_uri` (capsule artifact URI for patch/diff)
+- `apply_instructions` (how to apply/inspect safely)
+
+## Filesystem Projections (best-effort, proposal)
+
+> Projections are rebuildable from capsule artifacts; they are not authoritative (D114).
+
+- Proposed root: `docs/specs/<WORK_ITEM_ID>/runs/bot/<RUN_ID>/`
+- Suggested layout:
+  - `run_log.json`
+  - `research/research_report.md`
+  - `research/web_research_bundle.json` (if captured)
+  - `review/review_report.md`
+  - `review/patch.diff` (if produced)
+
+Capture-mode compliance:
+
+- `capture=none`: no projections/artifacts that would violate D131 (the runner may still display in-memory UI guidance).
+- `prompts_only`: projections must be export-safe (bounded snippets + hashes as defined by `WebResearchBundle` rules in `SPEC-PM-001`).
+- `full_io`: projections may include extracted content, but must remain excluded from safe export per policy.
 
 ## Minimal MVP (suggested)
 
@@ -68,23 +233,13 @@ All artifacts must respect capture mode (`none | prompts_only | full_io`) and ex
 - A command to place an item into `NeedsReview` and run a single deterministic/static review pass that emits:
   - `ReviewReport` with "must fix" vs "suggestions" plus a summarized risk list.
 
-## Definition of Done
-
-- PRD/design doc produced for this SPEC with:
-  - Bot runner execution model (on-demand vs queued), idempotency, and visibility in status surfaces.
-  - NotebookLM hard dependency behavior for `NeedsResearch` (blocked exit code + structured output; no fallback).
-  - Worktree/branch creation semantics and write boundaries (what may be written, and what is forbidden by default).
-  - TUI write-back mechanism for bot outputs (status/events + report linking).
-  - Artifact schemas + filesystem projection locations.
-  - Command surface proposal under `code speckit pm ...` (plus TUI alias mapping 1:1).
-  - Headless exit-code + JSON contract for bot runs.
-  - Safety boundaries (tool allowlist) and capture-mode compliance.
-
 ## Open Questions
 
-- Should the “bot runner/service” be tracked as its own dedicated SPEC (separate from PM semantics), with `SPEC-PM-002` focused on product semantics and surfaces?
+- Do we want a dedicated headless exit code for `BLOCKED`, or reuse exit code `2` with a structured `blocked_reason`?
+- What is the canonical filesystem projection root for PM work items (`docs/specs/<ID>/...` vs `.speckit/pm/...`), and which is Tier‑1 required?
 
 ## References
 
 - PM system PRD: `docs/SPEC-PM-001-project-management/PRD.md`
+- Bot system architecture: `docs/SPEC-PM-003-bot-system/spec.md`
 - Historical stub: `docs/SPEC-PM-001-project-management/TODO-bot-runner-spec.md`

--- a/docs/SPEC-PM-003-bot-system/spec.md
+++ b/docs/SPEC-PM-003-bot-system/spec.md
@@ -1,0 +1,169 @@
+# SPEC-PM-003: Bot System (Runner/Service/Tooling)
+
+## Status: PLANNED (design draft)
+
+## Overview
+
+Define the internal **bot system** that executes optional, manual automation for PM holding states:
+
+- `NeedsResearch` (research bots)
+- `NeedsReview` (validator/reviewer bots)
+
+`SPEC-PM-002` is the **interface contract** (how callers interact with bot runs across CLI/TUI/headless).  
+`SPEC-PM-003` is the **system design** (how the bot runner/service/tooling actually works).
+
+## Goals
+
+- Define the bot runner/service architecture and lifecycle.
+- Define scheduling/queueing, idempotency, and cancellation semantics.
+- Define the permission model and enforcement for tool execution + filesystem writes.
+- Define worktree/branch management for write-enabled review runs.
+- Define capsule event/artifact persistence and filesystem projection implementation.
+- Define observability (status events, logs, diagnostics) without violating capture-mode policy.
+
+## Non-Goals (initial)
+
+- Automatically starting bots on every work item by default.
+- Automatic PM state transitions (bots recommend; PM acts).
+- Cross-platform support (Linux-only remains baseline).
+- Auto-commit/push/merge as a default behavior.
+
+## Constraints (Already Locked)
+
+- **Tier‑1 multi-surface parity** (D113/D133): automation-critical behavior must match across CLI/TUI/headless.
+- **Headless never prompts** (D133): missing requirements → structured output + product exit codes.
+- **Maieutic step always mandatory** (D130): bot automation must not bypass required gates (especially `/speckit.auto`).
+- **Explainability follows capture mode** (D131) + **over-capture hard-block** (D119): the system must never persist more than policy allows; `capture=none` persists no explainability artifacts.
+- **No silent destructive actions in headless** (`SPEC-PM-001` NFR3): write operations require explicit user intent and must be auditable.
+- **Single-writer capsule** (D7): capsule writes are serialized; runner must not violate lock/queue invariants.
+
+## System Responsibilities (v1)
+
+- Accept bot run requests for a given work item + kind (`research | review`).
+- Build a deterministic context bundle from capsule + repo state.
+- Execute the appropriate engine:
+  - Research: NotebookLM synthesis (required) + web research
+  - Review: validator/reviewer pass + optional patch staging
+- Persist immutable artifacts (capsule SoR) + emit events.
+- Provide progress + final summaries to Tier‑1 surfaces (TUI + CLI + headless JSON).
+
+## Runtime Model (v1)
+
+### Placement + Lifecycle
+
+- Primary runtime: **background service spawned by the TUI** (tertiary service).
+- Service lifecycle expectations:
+  - Start on demand (when a bot run is triggered).
+  - Exit when idle (policy/configurable) to avoid “permanent daemon” posture.
+  - Expose a health/status endpoint for CLI/headless.
+
+### CLI/Headless Integration
+
+- CLI/headless must achieve Tier‑1 parity with the TUI runner semantics.
+- Preferred approach: CLI/headless connects to the runner service via an IPC protocol (exact transport TBD).
+- Acceptable fallback (if IPC is unavailable): in-process runner library with identical semantics.
+
+### Idempotency + Concurrency
+
+- Each run is identified by a unique `run_id`.
+- Recommended constraints:
+  - At most one active run per `(work_item_id, kind)`.
+  - Global concurrency bounded (CPU, network, capsule single-writer).
+- Cancellation:
+  - Best-effort, cooperative cancellation.
+  - Partial results must still be persisted with terminal `cancelled` status and a `BotRunLog`.
+
+## Components (conceptual)
+
+- **BotRunnerService**: run request API + job scheduling + progress reporting.
+- **Context Builder**: assembles deterministic inputs (work item fields + linked capsule artifacts + repo snapshot metadata).
+- **Research Engine**:
+  - NotebookLM client (required for `NeedsResearch`)
+  - Web research client(s): Tavily MCP preferred; generic web tooling fallback allowed
+- **Review Engine**:
+  - Local validation execution (allowlisted commands)
+  - Optional patch staging via worktree/branch
+- **Permission Enforcer**: centrally enforces read/write/network/tool allowlists and “no destructive actions” posture.
+- **Artifact Writer**: writes artifacts + emits capsule events (capture-mode aware).
+- **Projection Builder**: filesystem projection implementation (best-effort; rebuildable).
+- **UI Bridge**: publishes progress + summaries to TUI surfaces and CLI/headless JSON.
+
+## Tool Execution + Permissions (v1)
+
+### Default Posture
+
+- Default is **read-only** with respect to the user’s primary working tree.
+- Write capability must be explicitly enabled via interface flags (see `SPEC-PM-002`) and constrained to bot-owned worktrees.
+
+### NeedsResearch
+
+- Network allowed for web research (Tavily MCP preferred; generic fallback allowed).
+- **NotebookLM hard requirement**:
+  - If unavailable/unconfigured, the run terminates as `blocked` with structured output (no fallback research).
+- Must not create worktrees/branches or modify repo files.
+
+### NeedsReview
+
+- May run local validation commands under a strict allowlist (policy-defined).
+- May create a worktree/branch and stage changes when write mode is enabled.
+- Must never commit/push/merge by default.
+
+## Worktree + Branch Management (NeedsReview, v1)
+
+### Goals
+
+- Preserve user safety: never mutate the primary working tree by default.
+- Provide a reviewable, inspectable staging area for suggested changes.
+- Provide a patch artifact so review is possible without checkout.
+
+### Proposed Defaults
+
+- Worktree root: `./.speckit/worktrees/<work_item_id>/<run_id>/`
+- Branch name: `bot/<work_item_id>/<run_id>`
+
+### Required Outputs
+
+When write mode is enabled and changes are staged, the bot system must output:
+
+- `worktree_path`
+- `branch_name`
+- A `PatchBundle` artifact (includes a diff/patch reference + apply/inspect instructions)
+
+## Persistence: Events, Artifacts, Projections (v1)
+
+- Artifacts are authoritative SoR (D114); projections are rebuildable mirrors.
+- All persistence must be capture-mode compliant (D131/D119).
+- `prompts_only` should prefer export-safe templates + hashes (see `WebResearchBundle` contract in `SPEC-PM-001`).
+- `full_io` may store extracted content, but must remain excluded from safe export per policy.
+
+## Existing Building Blocks (already in Codex‑RS today)
+
+The bot system should reuse existing primitives rather than inventing new ones:
+
+- Agent runtime supports `read_only`, plus optional `worktree_path` and `branch_name`.
+  - `codex-rs/core/src/agent_tool.rs`
+- Agent status updates already flow into the main event stream.
+  - `codex-rs/core/src/codex.rs`
+- Capsule-backed grounding artifacts exist (good deterministic context bundle inputs).
+  - `codex-rs/tui/src/chatwidget/spec_kit/grounding.rs`
+- Structured Project Intel snapshot model exists.
+  - Schema: `codex-rs/stage0/src/project_intel/types.rs`
+  - TUI commands: `codex-rs/tui/src/chatwidget/spec_kit/commands/intel.rs`
+- NotebookLM integration surfaces exist.
+  - `codex-rs/cli/src/architect_cmd.rs`
+  - `codex-rs/cli/src/stage0_cmd.rs`
+- Local validation gates exist.
+  - `.githooks/pre-commit`
+  - `scripts/doc_lint.py`
+
+## Open Questions
+
+- What is the concrete IPC transport and auth boundary for CLI/headless → runner service (Unix socket vs stdio bridge vs in-process only)?
+- Where should a persistent run queue live (in-memory only vs capsule-backed queue events vs filesystem queue)?
+- Should `BLOCKED` become a dedicated headless exit code, or remain “exit 2 with structured blocked_reason” (per `SPEC-PM-002`)?
+- Which commands are on the initial allowlist for `NeedsReview`, and how do we represent policy overrides without violating D119/D125?
+
+## References
+
+- Interface contract: `docs/SPEC-PM-002-bot-runner/spec.md`
+- PM system PRD: `docs/SPEC-PM-001-project-management/PRD.md`

--- a/docs/briefs/docs__pm-bot-system-split.md
+++ b/docs/briefs/docs__pm-bot-system-split.md
@@ -1,0 +1,28 @@
+# Session Brief — docs/pm-bot-system-split
+
+## Goal
+
+Split the bot-runner documentation into:
+
+- `SPEC-PM-002`: interface contract (commands, headless contract, artifacts, caller-visible safety/write modes)
+- `SPEC-PM-003`: bot system design (runner/service/tooling internals)
+
+## Scope / Constraints
+
+- Docs-only (no Rust changes).
+- Tier‑1 parity and headless “never prompt” remain locked constraints (D113/D133).
+- NotebookLM is a hard requirement for `NeedsResearch` (no fallback research).
+- Write mode (for review) must remain isolated (worktree/branch) and never silently destructive.
+
+## Changes
+
+- Added `docs/SPEC-PM-003-bot-system/spec.md` (system design draft).
+- Refocused `docs/SPEC-PM-002-bot-runner/spec.md` into an interface contract.
+- Updated cross-references in `docs/SPEC-PM-001-project-management/PRD.md` and `codex-rs/SPEC.md`.
+
+## Verification
+
+- `python3 scripts/doc_lint.py`
+- `python3 scripts/check_doc_links.py`
+- `bash .githooks/pre-commit`
+

--- a/docs/briefs/docs__pm-bot-system-split.md
+++ b/docs/briefs/docs__pm-bot-system-split.md
@@ -26,3 +26,14 @@ Split the bot-runner documentation into:
 - `python3 scripts/check_doc_links.py`
 - `bash .githooks/pre-commit`
 
+<!-- BEGIN: SPECKIT_BRIEF_REFRESH -->
+## Product Knowledge (auto)
+
+- Query: `SPEC-PM-002 SPEC-PM-003 bot system NeedsResearch NeedsReview`
+- Domain: `codex-product`
+- Capsule URI: `mv2://default/WORKFLOW/brief-20260207T041858Z/artifact/briefs/docs__pm-bot-system-split/20260207T041858Z.md`
+- Capsule checkpoint: `brief-docs__pm-bot-system-split-20260207T041858Z`
+
+No high-signal product knowledge matched. Try a more specific `--query` and/or raise `--limit`.
+
+<!-- END: SPECKIT_BRIEF_REFRESH -->


### PR DESCRIPTION
Docs-only change.

- Refocus SPEC-PM-002 as the interface contract (commands, headless contract, artifacts, caller-visible safety/write modes)
- Add SPEC-PM-003 for bot system design (runner/service/tooling internals)
- Update tracker + PRD cross-references