### PR TITLE
fix(pm): align degraded banner with PM-UX-D14

### DIFF
--- a/docs/briefs/fix__pm-004-degraded-banner.md
+++ b/docs/briefs/fix__pm-004-degraded-banner.md
@@ -1,0 +1,26 @@
+# Session Brief — fix/pm-004-degraded-banner
+
+## Goal
+Align PM degraded banner UX to PM-UX-D14 with exact text in both list and detail views.
+
+## Scope / Constraints
+- No pm-service protocol or CLI behavior changes.
+- Keep PM detail view read-only.
+- Touch only `codex-rs/tui/src/chatwidget/pm_overlay.rs` plus this brief.
+
+## Decision / Spec Locks
+- `docs/DECISIONS.md`: D113, D138, D143 (Already Locked)
+- `docs/SPEC-PM-004-tui-ux/spec.md`: PM-UX-D14, PM-UX-D6/D12/D20
+
+<!-- BEGIN: SPECKIT_BRIEF_REFRESH -->
+
+## Product Knowledge (manual)
+
+- Query: `pm-004 degraded banner parity read-only detail list`
+- Domain: `spec-kit`
+- Capsule URI: `mv2://default/WORKFLOW/brief-20260213T182100Z/artifact/briefs/fix__pm-004-degraded-banner/20260213T182100Z.md`
+- Capsule checkpoint: `brief-fix__pm-004-degraded-banner-20260213T182100Z`
+
+Locked refs: D113, D138, D143; PM-UX-D14.
+
+<!-- END: SPECKIT_BRIEF_REFRESH -->


### PR DESCRIPTION
## Summary\n- align degraded banner text with PM-UX-D14 via single shared constant\n- render degraded banner in both list and detail views\n- add unit coverage for summary/detail degraded banner rendering\n- add branch brief for session context\n\n## Context\n- DEV_BRIEF.md\n- docs/DECISIONS.md: D113, D138, D143\n- docs/SPEC-PM-004-tui-ux/spec.md: PM-UX-D14\n\n## Verification\n- cd codex-rs && cargo fmt --all -- --check\n- cd codex-rs && cargo clippy -p codex-tui --all-targets --all-features -- -D warnings\n- cd codex-rs && cargo test -p codex-tui --lib