### PR TITLE
feat(pm): preserve list scroll position when returning from detail

### DIFF
--- a/docs/briefs/feat__pm-004-detail-return-position.md
+++ b/docs/briefs/feat__pm-004-detail-return-position.md
@@ -1,0 +1,98 @@
+# PM-004: Detail Return Position Preservation
+
+<!-- REFRESH-BLOCK
+query: "PM-004 detail return position preserve"
+snapshot: (none - read-only UI fix)
+END-REFRESH-BLOCK -->
+
+## Objective
+
+Preserve list selection and scroll position when returning from detail view to list view.
+
+## Spec
+
+* **PM-UX-D12**: Keyboard model
+* **PM-UX-D20**: Detail view layout and scrolling
+* **Decisions**: D138, D143
+
+## Problem
+
+List scroll position was being reset due to clamping logic in `render_list` that wrote back the clamped value, overwriting the user's scroll position when switching between modes.
+
+## Solution
+
+Fixed `set_scroll()` to store raw scroll value without clamping. Clamping now only happens during render for display purposes, preserving user's scroll position across mode changes.
+
+## Implementation
+
+### Changes
+
+1. **set\_scroll()** (pm\_overlay.rs):
+   * Removed clamping to `max_scroll` in setter
+   * Raw scroll value now preserved across mode switches
+   * Clamping still happens during render (read-only)
+
+2. **render\_list()** (pm\_overlay.rs):
+   * Removed `overlay.scroll.set(scroll as u16)` write-back
+   * Clamping only affects local `scroll` variable for rendering
+   * User's scroll value remains untouched
+
+3. **Tests added** (3 new tests):
+   * `test_list_scroll_preserved_after_detail_close` - Verifies scroll preservation
+   * `test_list_selection_and_scroll_both_preserved` - Verifies both selection and scroll
+   * `test_multiple_detail_open_close_preserves_position` - Verifies across multiple cycles
+
+### Root Cause
+
+**Before**:
+
+```rust
+pub(super) fn set_scroll(&self, val: u16) {
+    self.scroll.set(val.min(self.max_scroll.get())); // Clamped!
+}
+```
+
+**Issue**: If `max_scroll` was 0 (not yet calculated or in different mode), scroll gets clamped to 0.
+
+**After**:
+
+```rust
+pub(super) fn set_scroll(&self, val: u16) {
+    self.scroll.set(val); // Raw value preserved
+}
+```
+
+**Fix**: Store raw value; clamping only during render for display.
+
+## Behavior
+
+* **Enter detail**: List selection and scroll position saved
+* **Scroll in detail**: Detail scroll independent of list scroll
+* **Return to list** (Esc): List position exactly as it was
+* **Multiple cycles**: Position preserved across multiple detail open/close
+
+## Constraints Met
+
+* ✅ No protocol/CLI/RPC/service changes
+* ✅ Read-only / no mutations
+* ✅ Only touched pm\_overlay.rs and this brief (2 files, pm\_handlers.rs not needed)
+* ✅ LOC delta: \~70 lines (within budget of <= 120)
+
+## Testing
+
+```bash
+cd codex-rs && cargo test -p codex-tui --lib pm_overlay
+cd codex-rs && cargo test -p codex-tui --lib pm_handlers
+```
+
+Expected output: All tests pass (41 + 2 = 43 total)
+
+## Verification Checklist
+
+* [x] `cargo fmt --all -- --check` passes
+* [x] `cargo clippy -p codex-tui --all-targets --all-features -- -D warnings` passes
+* [x] `cargo test -p codex-tui --lib pm_overlay` passes (41/41)
+* [x] `cargo test -p codex-tui --lib pm_handlers` passes (2/2)
+* [x] Enter detail from any row, scroll in detail, press Esc → list returns to same row
+* [x] List scroll offset preserved (no jump to top)
+* [x] Existing detail/list key behaviors unchanged


### PR DESCRIPTION
## Summary
- Fixes scroll position reset bug when returning from detail view
- Preserves list selection and scroll across detail open/close cycles
- Adds comprehensive tests to prevent regressions

## Problem
List scroll position was being reset to 0 when:
1. User set scroll position in list
2. Opened detail view
3. Returned to list (Esc)

**Root cause**: `set_scroll()` clamped to `max_scroll` (often 0 before render), and `render_list()` wrote back clamped value.

## Solution
Remove premature clamping from scroll setters:
- **Before**: `set_scroll()` clamped to `max_scroll` → stored 0 if max_scroll was 0
- **After**: `set_scroll()` stores raw value → clamping only during render

## Changes
- **set_scroll()**: Remove clamping, store raw value
- **render_list()**: Remove scroll write-back, preserve user value
- **3 new tests**:
  - Scroll preserved after detail close
  - Selection + scroll both preserved
  - Position preserved across multiple cycles

## Behavior
- Enter detail from row 5, scroll 3 → opens detail
- Scroll detail view → detail scroll independent
- Press Esc → returns to row 5, scroll 3 (exact position)
- Multiple cycles → position always preserved

## Test Plan
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy -p codex-tui --all-targets --all-features -- -D warnings` passes
- [x] `cargo test -p codex-tui --lib pm_overlay` passes (41/41)
- [x] `cargo test -p codex-tui --lib pm_handlers` passes (2/2)
- [x] List scroll preserved across detail open/close
- [x] List selection preserved across detail open/close

## Decisions
D138, D143

🤖 Generated with [Claude Code](https://claude.com/claude-code)