### PR TITLE
Implement timeout for MCP tool calls

### DIFF
--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -5540,8 +5540,7 @@ async fn handle_function_call(
         _ => {
             match sess.mcp_connection_manager.parse_tool_name(&name) {
                 Some((server, tool_name)) => {
-                    // TODO(mbolin): Determine appropriate timeout for tool call.
-                    let timeout = None;
+                    let timeout = Some(sess.mcp_connection_manager.get_tool_timeout(server));
                     handle_mcp_tool_call(sess, &ctx, server, tool_name, arguments, timeout).await
                 }
                 None => {

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -5540,7 +5540,7 @@ async fn handle_function_call(
         _ => {
             match sess.mcp_connection_manager.parse_tool_name(&name) {
                 Some((server, tool_name)) => {
-                    let timeout = Some(sess.mcp_connection_manager.get_tool_timeout(server));
+                    let timeout = Some(sess.mcp_connection_manager.get_tool_timeout(&server));
                     handle_mcp_tool_call(sess, &ctx, server, tool_name, arguments, timeout).await
                 }
                 None => {


### PR DESCRIPTION
Implemented a configurable timeout for MCP tool calls. If not explicitly configured in `config.toml`, it defaults to 60 seconds (as per `McpServerConfig` documentation). The `McpConnectionManager` now tracks these timeouts per server and applies them when a tool is called.

---
*PR created automatically by Jules for task [11564038789631366129](https://jules.google.com/task/11564038789631366129) started by @zimmermanc*