### PR TITLE
🧹 Safe handling of reflex stats in speckit_cmd.rs

### DIFF
--- a/codex-rs/cli/src/speckit_cmd.rs
+++ b/codex-rs/cli/src/speckit_cmd.rs
@@ -6415,9 +6415,7 @@ fn run_reflex_bakeoff(args: ReflexBakeoffArgs) -> anyhow::Result<()> {
         }
 
         // Comparison summary
-        if stats.reflex.is_some() && stats.cloud.is_some() {
-            let reflex = stats.reflex.as_ref().unwrap();
-            let cloud = stats.cloud.as_ref().unwrap();
+        if let (Some(reflex), Some(cloud)) = (&stats.reflex, &stats.cloud) {
             println!();
             println!("  COMPARISON:");
             let latency_ratio = if cloud.p95_latency_ms > 0 {
@@ -8971,8 +8969,7 @@ fn output_projectnew_success(
 
         println!();
         println!("Next steps:");
-        if bootstrap.is_some() {
-            let b = bootstrap.unwrap();
+        if let Some(b) = bootstrap {
             println!("  cd {}", project_dir.display());
             println!(
                 "  code speckit run --spec {} --from plan --to plan --execute",


### PR DESCRIPTION
Identified and refactored two locations in `codex-rs/cli/src/speckit_cmd.rs` where `is_some()` was followed by `unwrap()`. These were replaced with `if let` pattern matching. This is a code health improvement that makes the code more robust and idiomatic.

1. In `run_reflex_bakeoff`, replaced:
   ```rust
   if stats.reflex.is_some() && stats.cloud.is_some() {
       let reflex = stats.reflex.as_ref().unwrap();
       let cloud = stats.cloud.as_ref().unwrap();
   ```
   with:
   ```rust
   if let (Some(reflex), Some(cloud)) = (&stats.reflex, &stats.cloud) {
   ```

2. In `output_projectnew_success`, replaced:
   ```rust
   if bootstrap.is_some() {
       let b = bootstrap.unwrap();
   ```
   with:
   ```rust
   if let Some(b) = bootstrap {
   ```

Verification was performed manually due to `cargo` timeouts in the sandbox environment. The changes follow standard Rust best practices.

---
*PR created automatically by Jules for task [3802896708935252788](https://jules.google.com/task/3802896708935252788) started by @zimmermanc*