### PR TITLE
🛡️ Sentinel: Enhance dangerous command detection

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-15 - Fragile Dangerous Command Detection
+**Vulnerability:** The dangerous command detection logic for `rm` and `git` relied on fixed argument positions (e.g., checking `argv[1]`). This allowed bypasses like `rm -v -rf /` or `git --no-pager reset`.
+**Learning:** Security heuristics based on command line arguments must account for flag reordering, combined flags (e.g., `-rf`), and global options appearing before subcommands.
+**Prevention:** Use robust argument parsing or iterate over all arguments to detect dangerous flags/subcommands, rather than checking specific indices. When in doubt, fail safe (flag as dangerous).


### PR DESCRIPTION
This PR enhances the `is_dangerous_command` logic in `codex-core` to provide better protection against accidental execution of destructive commands. 

Previous logic relied on fixed argument positions (e.g. checking `argv[1]`), which could be bypassed by flag reordering or global options. The new implementation scans arguments more thoroughly and adds checks for `dd` and `mkfs`.

This aligns with Sentinel's mission to identify and fix security enhancements.

---
*PR created automatically by Jules for task [6413648641989385782](https://jules.google.com/task/6413648641989385782) started by @zimmermanc*